### PR TITLE
Task/add basic auth

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -23,6 +23,7 @@
   <suppress checks="ClassDataAbstractionCoupling" files="(IntegrationTest|ConnectRunner).java" />
   <suppress checks="MethodLength" files="(HttpSinkConfig).java" />
   <suppress checks="CyclomaticComplexity" files="(HttpSinkConfig).java" />
+  <suppress checks="ClassFanOutComplexit" files="(HttpSenderFactory).java" />
   <suppress checks="JavaNCSS" files="HttpSinkConfig.java" />
 
 </suppressions>

--- a/docs/sink-connector-config-options.rst
+++ b/docs/sink-connector-config-options.rst
@@ -128,6 +128,95 @@ Connection
   * Importance: low
   * Dependents: ``oauth2.access.token.url``, ``oauth2.client.id``, ``oauth2.client.secret``, ``oauth2.client.authorization.mode``, ``oauth2.client.scope``
 
+
+Basic Authentication
+^^^^^^^^^^^^^^^^^^^^
+
+``basic.access.token.url``
+  The URL to be used for fetching an access token. Client Credentials is the only supported grant type.
+
+  * Type: string
+  * Default: null
+  * Valid Values: HTTP(S) URL
+  * Importance: high
+  * Dependents: ``basic.request.client.id.property``, ``basic.client.id``, ``basic.request.client.secret.property``, ``basic.client.secret``, ``basic.request.username.property``, ``basic.username``, ``basic.request.password.property``, ``basic.password``, ``basic.client.scope``
+
+``basic.request.client.id.property``
+  The client id Key used for fetching an access token.
+
+  * Type: string
+  * Default: "client_id"
+  * Importance: high
+  * Dependents: ``basic.client.id``
+
+``basic.client.id``
+  The client id used for fetching an access token.
+
+  * Type: string
+  * Default: null
+  * Valid Values: Basic Auth client id
+  * Importance: high
+  * Dependents: ``basic.access.token.url``, ``basic.client.secret``, ``basic.client.scope``
+
+``basic.request.client.secret.property``
+  The client secret Key used for fetching an access token.
+
+  * Type: string
+  * Default: "client_secret"
+  * Importance: high
+  * Dependents: ``basic.client.secret``
+
+``basic.client.secret``
+  The secret used for fetching an access token.
+
+  * Type: password
+  * Default: null
+  * Importance: high
+  * Dependents: ``basic.access.token.url``, ``basic.client.id``, ``basic.client.scope``
+
+``basic.request.username.property``
+  The username Key used for fetching an access token.
+
+  * Type: string
+  * Default: "username"
+  * Importance: high
+  * Dependents: ``basic.username``
+
+``basic.username``
+  The username used for fetching an access token.
+
+  * Type: string
+  * Default: null
+  * Valid Values: Basic Auth username
+  * Importance: high
+  * Dependents: ``basic.access.token.url``, ``basic.password``, ``basic.client.scope``
+
+``basic.request.password.property``
+  The password Key used for fetching an access token.
+
+  * Type: string
+  * Default: "password"
+  * Importance: high
+  * Dependents: ``basic.password``
+
+``basic.password``
+  The password used for fetching an access token.
+
+  * Type: password
+  * Default: null
+  * Importance: high
+  * Dependents: ``basic.access.token.url``, ``basic.username``, ``basic.client.scope``
+
+``basic.client.scope``
+  The scope used for fetching an access token.
+
+  * Type: string
+  * Default: null
+  * Valid Values: Basic Auth client scope
+  * Importance: low
+  * Dependents: ``basic.access.token.url``, ``basic.client.id``, ``basic.client.secret``, ``basic.username``, ``basic.password``
+
+
 Batching
 ^^^^^^^^
 

--- a/docs/sink-connector-config-options.rst
+++ b/docs/sink-connector-config-options.rst
@@ -304,6 +304,14 @@ Errors Handling
   * Default: null
   * Importance: low
 
+
+``http.graphql.errors.as.http_error``
+  If true, treat HTTP 200 responses containing a non-empty GraphQL 'errors' array as failures.
+  * Type: boolean
+  * Default: true
+  * Importance: low
+
+
 Formatting
 ^^^^^^^^^^^^^^^
 

--- a/src/main/java/io/aiven/kafka/connect/http/config/AuthorizationType.java
+++ b/src/main/java/io/aiven/kafka/connect/http/config/AuthorizationType.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 
 public enum AuthorizationType {
     NONE("none"),
+    BASIC("basic"),
     OAUTH2("oauth2"),
     STATIC("static");
 
@@ -37,6 +38,8 @@ public enum AuthorizationType {
 
         if (NONE.name.equalsIgnoreCase(name)) {
             return NONE;
+        } else if (BASIC.name.equalsIgnoreCase(name)) {
+            return BASIC;
         } else if (OAUTH2.name.equalsIgnoreCase(name)) {
             return OAUTH2;
         } else if (STATIC.name.equalsIgnoreCase(name)) {

--- a/src/main/java/io/aiven/kafka/connect/http/config/BasicAuthAuthorizationMode.java
+++ b/src/main/java/io/aiven/kafka/connect/http/config/BasicAuthAuthorizationMode.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Aiven Oy and http-connector-for-apache-kafka project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.http.config;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public enum BasicAuthAuthorizationMode {
+
+    HEADER,
+    URL;
+
+    static final List<String> BASIC_AUTH_AUTHORIZATION_MODES =
+            Arrays.stream(BasicAuthAuthorizationMode.values())
+                    .map(BasicAuthAuthorizationMode::name)
+                    .collect(Collectors.toUnmodifiableList());
+
+}

--- a/src/main/java/io/aiven/kafka/connect/http/config/BasicAuthAuthorizationMode.java
+++ b/src/main/java/io/aiven/kafka/connect/http/config/BasicAuthAuthorizationMode.java
@@ -25,7 +25,7 @@ public enum BasicAuthAuthorizationMode {
     HEADER,
     URL;
 
-    static final List<String> BASIC_AUTH_AUTHORIZATION_MODES =
+    static final List<String> BASIC_AUTHORIZATION_MODES =
             Arrays.stream(BasicAuthAuthorizationMode.values())
                     .map(BasicAuthAuthorizationMode::name)
                     .collect(Collectors.toUnmodifiableList());

--- a/src/main/java/io/aiven/kafka/connect/http/config/HttpSinkConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/http/config/HttpSinkConfig.java
@@ -64,6 +64,21 @@ public final class HttpSinkConfig extends AbstractConfig {
     private static final String OAUTH2_CLIENT_SCOPE_CONFIG = "oauth2.client.scope";
     private static final String OAUTH2_RESPONSE_TOKEN_PROPERTY_CONFIG = "oauth2.response.token.property";
 
+    private static final String BASIC_ACCESS_TOKEN_URL_CONFIG = "basic.access.token.url";
+    private static final String BASIC_GRANT_TYPE_PROP_CONFIG = "basic.request.grant.type.property";
+    private static final String BASIC_GRANT_TYPE_CONFIG = "basic.grant.type";
+    private static final String BASIC_CLIENT_ID_PROP_CONFIG = "basic.request.client.id.property";
+    private static final String BASIC_CLIENT_ID_CONFIG = "basic.client.id";
+    private static final String BASIC_CLIENT_SECRET_PROP_CONFIG = "basic.request.client.secret.property";
+    private static final String BASIC_CLIENT_SECRET_CONFIG = "basic.client.secret";
+    private static final String BASIC_USERNAME_PROP_CONFIG = "basic.request.username.property";
+    private static final String BASIC_USERNAME_CONFIG = "basic.username";
+    private static final String BASIC_PASSWORD_PROP_CONFIG = "basic.request.password.property";
+    private static final String BASIC_PASSWORD_CONFIG = "basic.password";
+    private static final String BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG = "basic.client.authorization.mode";
+    private static final String BASIC_CLIENT_SCOPE_CONFIG = "basic.client.scope";
+    private static final String BASIC_RESPONSE_TOKEN_PROPERTY_CONFIG = "basic.response.token.property";
+
     private static final String BATCHING_GROUP = "Batching";
     private static final String BATCHING_ENABLED_CONFIG = "batching.enabled";
     private static final String BATCH_MAX_SIZE_CONFIG = "batch.max.size";
@@ -424,6 +439,264 @@ public final class HttpSinkConfig extends AbstractConfig {
                 List.of(OAUTH2_ACCESS_TOKEN_URL_CONFIG, OAUTH2_CLIENT_ID_CONFIG, OAUTH2_CLIENT_SECRET_CONFIG,
                         OAUTH2_CLIENT_AUTHORIZATION_MODE_CONFIG, OAUTH2_CLIENT_SCOPE_CONFIG)
         );
+
+
+        configDef.define(
+                BASIC_ACCESS_TOKEN_URL_CONFIG,
+                ConfigDef.Type.STRING,
+                null,
+                new UrlValidator(true),
+                ConfigDef.Importance.HIGH,
+                "The URL to be used for fetching an access token. "
+                        + "Client Credentials is the only supported grant type.",
+                CONNECTION_GROUP,
+                groupCounter++,
+                ConfigDef.Width.LONG,
+                BASIC_ACCESS_TOKEN_URL_CONFIG,
+                List.of(BASIC_GRANT_TYPE_PROP_CONFIG, BASIC_GRANT_TYPE_CONFIG, BASIC_CLIENT_ID_PROP_CONFIG,
+                        BASIC_CLIENT_ID_CONFIG, BASIC_CLIENT_SECRET_PROP_CONFIG, BASIC_CLIENT_SECRET_CONFIG,
+                        BASIC_USERNAME_PROP_CONFIG,
+                        BASIC_USERNAME_CONFIG, BASIC_PASSWORD_PROP_CONFIG, BASIC_PASSWORD_CONFIG,
+                        BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG, BASIC_CLIENT_SCOPE_CONFIG,
+                        BASIC_RESPONSE_TOKEN_PROPERTY_CONFIG)
+        );
+        configDef.define(BASIC_GRANT_TYPE_PROP_CONFIG,
+                ConfigDef.Type.STRING,
+                "grant_type",
+                new ConfigDef.NonEmptyStringWithoutControlChars() {
+                    @Override
+                    public String toString() {
+                        return "Basic Auth grant type key";
+                    }
+                },
+                ConfigDef.Importance.HIGH,
+                "The grant type Key used for fetching an access token.",
+                CONNECTION_GROUP,
+                groupCounter++,
+                ConfigDef.Width.LONG, BASIC_GRANT_TYPE_PROP_CONFIG,
+                List.of(BASIC_GRANT_TYPE_CONFIG)
+        );
+        configDef.define(
+                BASIC_GRANT_TYPE_CONFIG,
+                ConfigDef.Type.STRING,
+                "client_credentials",
+                new ConfigDef.NonEmptyStringWithoutControlChars() {
+                    @Override
+                    public String toString() {
+                        return "Basic Auth grant type";
+                    }
+                },
+                ConfigDef.Importance.HIGH,
+                "The grant type used for fetching an access token.",
+                CONNECTION_GROUP,
+                groupCounter++,
+                ConfigDef.Width.LONG,
+                BASIC_GRANT_TYPE_CONFIG
+        );
+        configDef.define(BASIC_CLIENT_ID_PROP_CONFIG,
+                ConfigDef.Type.STRING,
+                "client_id",
+                new ConfigDef.NonEmptyStringWithoutControlChars() {
+                    @Override
+                    public String toString() {
+                        return "Basic Auth client id Key";
+                    }
+                },
+                ConfigDef.Importance.HIGH,
+                "The client id Key used for fetching an access token.",
+                CONNECTION_GROUP,
+                groupCounter++,
+                ConfigDef.Width.LONG, BASIC_CLIENT_ID_PROP_CONFIG,
+                List.of(BASIC_CLIENT_ID_CONFIG)
+        );
+        configDef.define(
+                BASIC_CLIENT_ID_CONFIG,
+                ConfigDef.Type.STRING,
+                null,
+                new ConfigDef.NonEmptyStringWithoutControlChars() {
+                    @Override
+                    public String toString() {
+                        return "Basic Auth client id";
+                    }
+                },
+                ConfigDef.Importance.HIGH,
+                "The client id used for fetching an access token.",
+                CONNECTION_GROUP,
+                groupCounter++,
+                ConfigDef.Width.LONG,
+                BASIC_CLIENT_ID_CONFIG,
+                List.of(BASIC_ACCESS_TOKEN_URL_CONFIG, BASIC_CLIENT_SECRET_CONFIG,
+                        BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG,
+                        BASIC_CLIENT_SCOPE_CONFIG, BASIC_RESPONSE_TOKEN_PROPERTY_CONFIG)
+        );
+        configDef.define(BASIC_CLIENT_SECRET_PROP_CONFIG,
+                Type.STRING,
+                "client_secret",
+                ConfigDef.Importance.HIGH,
+                "The secret Key used for fetching an access token.",
+                CONNECTION_GROUP,
+                groupCounter++,
+                ConfigDef.Width.LONG, BASIC_CLIENT_SECRET_PROP_CONFIG,
+                List.of(BASIC_CLIENT_SECRET_CONFIG)
+        );
+        configDef.define(
+                BASIC_CLIENT_SECRET_CONFIG,
+                ConfigDef.Type.PASSWORD,
+                null,
+                ConfigDef.Importance.HIGH,
+                "The secret used for fetching an access token.",
+                CONNECTION_GROUP,
+                groupCounter++,
+                ConfigDef.Width.LONG,
+                BASIC_CLIENT_SECRET_CONFIG,
+                List.of(BASIC_ACCESS_TOKEN_URL_CONFIG, BASIC_CLIENT_ID_CONFIG,
+                        BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG,
+                        BASIC_CLIENT_SCOPE_CONFIG, BASIC_RESPONSE_TOKEN_PROPERTY_CONFIG)
+        );
+
+        configDef.define(BASIC_USERNAME_PROP_CONFIG,
+                ConfigDef.Type.STRING,
+                "username",
+                new ConfigDef.NonEmptyStringWithoutControlChars() {
+                    @Override
+                    public String toString() {
+                        return "Basic Auth username Key";
+                    }
+                },
+                ConfigDef.Importance.HIGH,
+                "The username Key used for fetching an access token.",
+                CONNECTION_GROUP,
+                groupCounter++,
+                ConfigDef.Width.LONG, BASIC_USERNAME_PROP_CONFIG,
+                List.of(BASIC_USERNAME_CONFIG)
+        );
+        configDef.define(
+                BASIC_USERNAME_CONFIG,
+                ConfigDef.Type.STRING,
+                null,
+                new ConfigDef.NonEmptyStringWithoutControlChars() {
+                    @Override
+                    public String toString() {
+                        return "Basic Auth client id";
+                    }
+                },
+                ConfigDef.Importance.HIGH,
+                "The username used for fetching an access token.",
+                CONNECTION_GROUP,
+                groupCounter++,
+                ConfigDef.Width.LONG,
+                BASIC_USERNAME_CONFIG,
+                List.of(BASIC_ACCESS_TOKEN_URL_CONFIG, BASIC_PASSWORD_CONFIG,
+                        BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG,
+                        BASIC_CLIENT_SCOPE_CONFIG, BASIC_RESPONSE_TOKEN_PROPERTY_CONFIG)
+        );
+        configDef.define(BASIC_PASSWORD_PROP_CONFIG,
+                Type.STRING,
+                "password",
+                ConfigDef.Importance.HIGH,
+                "The password used for fetching an access token.",
+                CONNECTION_GROUP,
+                groupCounter++,
+                ConfigDef.Width.LONG, BASIC_PASSWORD_PROP_CONFIG,
+                List.of(BASIC_PASSWORD_CONFIG)
+        );
+        configDef.define(
+                BASIC_PASSWORD_CONFIG,
+                ConfigDef.Type.PASSWORD,
+                null,
+                ConfigDef.Importance.HIGH,
+                "The password used for fetching an access token.",
+                CONNECTION_GROUP,
+                groupCounter++,
+                ConfigDef.Width.LONG,
+                BASIC_PASSWORD_CONFIG,
+                List.of(BASIC_ACCESS_TOKEN_URL_CONFIG, BASIC_USERNAME_CONFIG,
+                        BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG,
+                        BASIC_CLIENT_SCOPE_CONFIG, BASIC_RESPONSE_TOKEN_PROPERTY_CONFIG)
+        );
+        
+        configDef.define(
+                BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG,
+                ConfigDef.Type.STRING,
+                BasicAuthAuthorizationMode.HEADER.name(),
+                new ConfigDef.Validator() {
+                    @Override
+                    public void ensureValid(final String name, final Object value) {
+                        if (value == null) {
+                            throw new ConfigException(name, null, "can't be null");
+                        }
+                        if (!(value instanceof String)) {
+                            throw new ConfigException(name, value, "must be string");
+                        }
+                        if (!BasicAuthAuthorizationMode.BASIC_AUTHORIZATION_MODES
+                                .contains(value.toString().toUpperCase())) {
+                            throw new ConfigException(
+                                    BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG, value,
+                                    "supported values are: " + BasicAuthAuthorizationMode.BASIC_AUTHORIZATION_MODES);
+                        }
+                    }
+
+                    @Override
+                    public String toString() {
+                        return String.join(",", BasicAuthAuthorizationMode.BASIC_AUTHORIZATION_MODES);
+                    }
+                },
+                ConfigDef.Importance.MEDIUM,
+                "Specifies how to encode ``client_id``, ``client_secret``, ``username`` and ``password`` in the Basic authorization request. "
+                        + "If set to ``header``, the credentials are encoded as an "
+                        + "``Authorization: Basic <base-64 encoded client_id:client_secret>`` HTTP header. "
+                        + "If set to ``url``, then ``client_id`` and ``client_secret`` "
+                        + "are sent as URL encoded parameters. Default is ``header``.",
+                CONNECTION_GROUP,
+                groupCounter++,
+                ConfigDef.Width.LONG,
+                BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG,
+                List.of(BASIC_ACCESS_TOKEN_URL_CONFIG, BASIC_CLIENT_ID_CONFIG, BASIC_CLIENT_SECRET_CONFIG,
+                        BASIC_USERNAME_CONF, BASIC_PASSWORD_CONF,
+                        BASIC_CLIENT_SCOPE_CONFIG, BASIC_RESPONSE_TOKEN_PROPERTY_CONFIG)
+        );
+        configDef.define(
+                BASIC_CLIENT_SCOPE_CONFIG,
+                ConfigDef.Type.STRING,
+                null,
+                new ConfigDef.NonEmptyStringWithoutControlChars() {
+                    @Override
+                    public String toString() {
+                        return "Basic Auth client scope";
+                    }
+                },
+                ConfigDef.Importance.LOW,
+                "The scope used for fetching an access token.",
+                CONNECTION_GROUP,
+                groupCounter++,
+                ConfigDef.Width.LONG,
+                BASIC_CLIENT_SCOPE_CONFIG,
+                List.of(BASIC_ACCESS_TOKEN_URL_CONFIG, BASIC_CLIENT_ID_CONFIG, BASIC_CLIENT_SECRET_CONFIG,
+                        BASIC_USERNAME_CONFIG, BASIC_PASSWORD_CONFIG,
+                        BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG, BASIC_RESPONSE_TOKEN_PROPERTY_CONFIG)
+        );
+        configDef.define(
+                BASIC_RESPONSE_TOKEN_PROPERTY_CONFIG,
+                ConfigDef.Type.STRING,
+                "access_token",
+                new ConfigDef.NonEmptyStringWithoutControlChars() {
+                    @Override
+                    public String toString() {
+                        return "Basic Auth response token";
+                    }
+                },
+                ConfigDef.Importance.LOW,
+                "The name of the JSON property containing the access token returned "
+                        + "by the Basic Auth provider. Default value is ``access_token``.",
+                CONNECTION_GROUP,
+                groupCounter++,
+                ConfigDef.Width.LONG,
+                BASIC_RESPONSE_TOKEN_PROPERTY_CONFIG,
+                List.of(BASIC_ACCESS_TOKEN_URL_CONFIG, BASIC_CLIENT_ID_CONFIG, BASIC_CLIENT_SECRET_CONFIG,
+                        BASIC_USERNAME_CONFIG, BASIC_PASSWORD_CONFIG,
+                        BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG, BASIC_CLIENT_SCOPE_CONFIG)
+        );
+        
     }
 
     private static void addBatchingConfigGroup(final ConfigDef configDef) {
@@ -630,6 +903,8 @@ public final class HttpSinkConfig extends AbstractConfig {
                 break;
             case OAUTH2: validateOAuth2Configuration();
                 break;
+            case BASIC: validateOBasicAuthConfiguration();
+                break;                
             case NONE:
                 if (headerAuthorization() != null && !headerAuthorization().isBlank()) {
                     throw new ConfigException(
@@ -671,6 +946,29 @@ public final class HttpSinkConfig extends AbstractConfig {
                     "Must be present when " + HTTP_HEADERS_AUTHORIZATION_CONFIG + " = " + AuthorizationType.OAUTH2);
         }
     }
+
+    private void validateBasicAuthConfiguration() {
+        Stream.of(BASIC_ACCESS_TOKEN_URL_CONFIG, BASIC_GRANT_TYPE_PROP_CONFIG, BASIC_GRANT_TYPE_CONFIG,
+                  BASIC_CLIENT_ID_PROP_CONFIG, BASIC_CLIENT_ID_CONFIG, BASIC_CLIENT_SECRET_PROP_CONFIG,
+                  BASIC_USERNAME_PROP_CONFIG, BASIC_USERNAME_CONFIG, BASIC_PASSWORD_PROP_CONFIG)
+              .filter(configKey -> getString(configKey) == null || getString(configKey).isBlank())
+              .findFirst()
+              .ifPresent(missingConfiguration -> {
+                  throw new ConfigException(missingConfiguration, getString(missingConfiguration),
+                          "Must be present when " + HTTP_HEADERS_AUTHORIZATION_CONFIG + " = "
+                          +
+                          AuthorizationType.BASIC);
+              });
+
+        if (basicAuthClientSecret() == null || basicAuthClientSecret().value().isEmpty()) {
+            throw new ConfigException(BASIC_CLIENT_SECRET_CONFIG, basicAuthClientSecret(),
+                    "Must be present when " + HTTP_HEADERS_AUTHORIZATION_CONFIG + " = " + AuthorizationType.BASIC);
+        }
+        if (basicAuthPassword() == null || basicAuthPassword().value().isEmpty()) {
+            throw new ConfigException(BASIC_PASSWORD_CONFIG, basicAuthPassword(),
+                    "Must be present when " + HTTP_HEADERS_AUTHORIZATION_CONFIG + " = " + AuthorizationType.BASIC);
+        }        
+    }    
 
     public final URI httpUri() {
         return toURI(HTTP_URL_CONFIG);
@@ -793,6 +1091,18 @@ public final class HttpSinkConfig extends AbstractConfig {
 
     public final String oauth2ResponseTokenProperty() {
         return getString(OAUTH2_RESPONSE_TOKEN_PROPERTY_CONFIG);
+    }
+
+    public final basicAuthAuthorizationMode basicAuthAuthorizationMode() {
+        return BasicAuthAuthorizationMode.valueOf(getString(BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG).toUpperCase());
+    }
+
+    public final String basicAuthClientScope() {
+        return getString(BASIC_CLIENT_SCOPE_CONFIG);
+    }
+
+    public final String basicAuthResponseTokenProperty() {
+        return getString(BASIC_RESPONSE_TOKEN_PROPERTY_CONFIG);
     }
 
     public final boolean hasProxy() {

--- a/src/main/java/io/aiven/kafka/connect/http/config/HttpSinkConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/http/config/HttpSinkConfig.java
@@ -92,6 +92,8 @@ public final class HttpSinkConfig extends AbstractConfig {
     private static final String TIMEOUT_GROUP = "Timeout";
     private static final String HTTP_TIMEOUT_CONFIG = "http.timeout";
 
+    private static final String HTTP_GRAPHQL_ERRORS_AS_HTTP_ERROR_CONFIG = "http.graphql.errors.as.http_error";
+
     private static final String FORMATING_GROUP = "Format";
     private static final String AVRO_DECIMAL_FORMAT_CONFIG = "decimal.format";
 
@@ -245,6 +247,18 @@ public final class HttpSinkConfig extends AbstractConfig {
                 groupCounter++,
                 ConfigDef.Width.MEDIUM,
                 HTTP_HEADERS_ADDITIONAL
+        );
+
+        configDef.define(
+                HTTP_GRAPHQL_ERRORS_AS_HTTP_ERROR_CONFIG,
+                ConfigDef.Type.BOOLEAN,
+                true,
+                ConfigDef.Importance.LOW,
+                "If true, treat HTTP 200 responses containing a non-empty GraphQL 'errors' array as failures.",
+                ERRORS_GROUP,
+                groupCounter++,
+                ConfigDef.Width.SHORT,
+                HTTP_GRAPHQL_ERRORS_AS_HTTP_ERROR_CONFIG
         );
 
         configDef.define(
@@ -934,6 +948,10 @@ public final class HttpSinkConfig extends AbstractConfig {
 
     public int httpTimeout() {
         return getInt(HTTP_TIMEOUT_CONFIG);
+    }
+
+    public final boolean graphqlErrorsAsHttpError() {
+        return getBoolean(HTTP_GRAPHQL_ERRORS_AS_HTTP_ERROR_CONFIG);
     }
 
     public final String connectorName() {

--- a/src/main/java/io/aiven/kafka/connect/http/config/HttpSinkConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/http/config/HttpSinkConfig.java
@@ -758,7 +758,7 @@ public final class HttpSinkConfig extends AbstractConfig {
             ERRORS_GROUP,
             groupCounter++,
             ConfigDef.Width.SHORT,
-            HTTP_TIMEOUT_CONFIG
+            ERRORS_TOLERANCE
         );
     }
 

--- a/src/main/java/io/aiven/kafka/connect/http/config/HttpSinkConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/http/config/HttpSinkConfig.java
@@ -65,8 +65,6 @@ public final class HttpSinkConfig extends AbstractConfig {
     private static final String OAUTH2_RESPONSE_TOKEN_PROPERTY_CONFIG = "oauth2.response.token.property";
 
     private static final String BASIC_ACCESS_TOKEN_URL_CONFIG = "basic.access.token.url";
-    private static final String BASIC_GRANT_TYPE_PROP_CONFIG = "basic.request.grant.type.property";
-    private static final String BASIC_GRANT_TYPE_CONFIG = "basic.grant.type";
     private static final String BASIC_CLIENT_ID_PROP_CONFIG = "basic.request.client.id.property";
     private static final String BASIC_CLIENT_ID_CONFIG = "basic.client.id";
     private static final String BASIC_CLIENT_SECRET_PROP_CONFIG = "basic.request.client.secret.property";
@@ -75,9 +73,7 @@ public final class HttpSinkConfig extends AbstractConfig {
     private static final String BASIC_USERNAME_CONFIG = "basic.username";
     private static final String BASIC_PASSWORD_PROP_CONFIG = "basic.request.password.property";
     private static final String BASIC_PASSWORD_CONFIG = "basic.password";
-    private static final String BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG = "basic.client.authorization.mode";
     private static final String BASIC_CLIENT_SCOPE_CONFIG = "basic.client.scope";
-    private static final String BASIC_RESPONSE_TOKEN_PROPERTY_CONFIG = "basic.response.token.property";
 
     private static final String BATCHING_GROUP = "Batching";
     private static final String BATCHING_ENABLED_CONFIG = "batching.enabled";
@@ -453,45 +449,11 @@ public final class HttpSinkConfig extends AbstractConfig {
                 groupCounter++,
                 ConfigDef.Width.LONG,
                 BASIC_ACCESS_TOKEN_URL_CONFIG,
-                List.of(BASIC_GRANT_TYPE_PROP_CONFIG, BASIC_GRANT_TYPE_CONFIG, BASIC_CLIENT_ID_PROP_CONFIG,
+                List.of(BASIC_CLIENT_ID_PROP_CONFIG,
                         BASIC_CLIENT_ID_CONFIG, BASIC_CLIENT_SECRET_PROP_CONFIG, BASIC_CLIENT_SECRET_CONFIG,
                         BASIC_USERNAME_PROP_CONFIG,
                         BASIC_USERNAME_CONFIG, BASIC_PASSWORD_PROP_CONFIG, BASIC_PASSWORD_CONFIG,
-                        BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG, BASIC_CLIENT_SCOPE_CONFIG,
-                        BASIC_RESPONSE_TOKEN_PROPERTY_CONFIG)
-        );
-        configDef.define(BASIC_GRANT_TYPE_PROP_CONFIG,
-                ConfigDef.Type.STRING,
-                "grant_type",
-                new ConfigDef.NonEmptyStringWithoutControlChars() {
-                    @Override
-                    public String toString() {
-                        return "Basic Auth grant type key";
-                    }
-                },
-                ConfigDef.Importance.HIGH,
-                "The grant type Key used for fetching an access token.",
-                CONNECTION_GROUP,
-                groupCounter++,
-                ConfigDef.Width.LONG, BASIC_GRANT_TYPE_PROP_CONFIG,
-                List.of(BASIC_GRANT_TYPE_CONFIG)
-        );
-        configDef.define(
-                BASIC_GRANT_TYPE_CONFIG,
-                ConfigDef.Type.STRING,
-                "client_credentials",
-                new ConfigDef.NonEmptyStringWithoutControlChars() {
-                    @Override
-                    public String toString() {
-                        return "Basic Auth grant type";
-                    }
-                },
-                ConfigDef.Importance.HIGH,
-                "The grant type used for fetching an access token.",
-                CONNECTION_GROUP,
-                groupCounter++,
-                ConfigDef.Width.LONG,
-                BASIC_GRANT_TYPE_CONFIG
+                        BASIC_CLIENT_SCOPE_CONFIG)
         );
         configDef.define(BASIC_CLIENT_ID_PROP_CONFIG,
                 ConfigDef.Type.STRING,
@@ -526,8 +488,7 @@ public final class HttpSinkConfig extends AbstractConfig {
                 ConfigDef.Width.LONG,
                 BASIC_CLIENT_ID_CONFIG,
                 List.of(BASIC_ACCESS_TOKEN_URL_CONFIG, BASIC_CLIENT_SECRET_CONFIG,
-                        BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG,
-                        BASIC_CLIENT_SCOPE_CONFIG, BASIC_RESPONSE_TOKEN_PROPERTY_CONFIG)
+                        BASIC_CLIENT_SCOPE_CONFIG)
         );
         configDef.define(BASIC_CLIENT_SECRET_PROP_CONFIG,
                 Type.STRING,
@@ -550,8 +511,7 @@ public final class HttpSinkConfig extends AbstractConfig {
                 ConfigDef.Width.LONG,
                 BASIC_CLIENT_SECRET_CONFIG,
                 List.of(BASIC_ACCESS_TOKEN_URL_CONFIG, BASIC_CLIENT_ID_CONFIG,
-                        BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG,
-                        BASIC_CLIENT_SCOPE_CONFIG, BASIC_RESPONSE_TOKEN_PROPERTY_CONFIG)
+                        BASIC_CLIENT_SCOPE_CONFIG)
         );
 
         configDef.define(BASIC_USERNAME_PROP_CONFIG,
@@ -587,8 +547,7 @@ public final class HttpSinkConfig extends AbstractConfig {
                 ConfigDef.Width.LONG,
                 BASIC_USERNAME_CONFIG,
                 List.of(BASIC_ACCESS_TOKEN_URL_CONFIG, BASIC_PASSWORD_CONFIG,
-                        BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG,
-                        BASIC_CLIENT_SCOPE_CONFIG, BASIC_RESPONSE_TOKEN_PROPERTY_CONFIG)
+                        BASIC_CLIENT_SCOPE_CONFIG)
         );
         configDef.define(BASIC_PASSWORD_PROP_CONFIG,
                 Type.STRING,
@@ -611,51 +570,9 @@ public final class HttpSinkConfig extends AbstractConfig {
                 ConfigDef.Width.LONG,
                 BASIC_PASSWORD_CONFIG,
                 List.of(BASIC_ACCESS_TOKEN_URL_CONFIG, BASIC_USERNAME_CONFIG,
-                        BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG,
-                        BASIC_CLIENT_SCOPE_CONFIG, BASIC_RESPONSE_TOKEN_PROPERTY_CONFIG)
+                        BASIC_CLIENT_SCOPE_CONFIG)
         );
 
-        configDef.define(
-                BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG,
-                ConfigDef.Type.STRING,
-                BasicAuthAuthorizationMode.HEADER.name(),
-                new ConfigDef.Validator() {
-                    @Override
-                    public void ensureValid(final String name, final Object value) {
-                        if (value == null) {
-                            throw new ConfigException(name, null, "can't be null");
-                        }
-                        if (!(value instanceof String)) {
-                            throw new ConfigException(name, value, "must be string");
-                        }
-                        if (!BasicAuthAuthorizationMode.BASIC_AUTHORIZATION_MODES
-                                .contains(value.toString().toUpperCase())) {
-                            throw new ConfigException(
-                                    BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG, value,
-                                    "supported values are: " + BasicAuthAuthorizationMode.BASIC_AUTHORIZATION_MODES);
-                        }
-                    }
-
-                    @Override
-                    public String toString() {
-                        return String.join(",", BasicAuthAuthorizationMode.BASIC_AUTHORIZATION_MODES);
-                    }
-                },
-                ConfigDef.Importance.MEDIUM,
-                "Specifies how to encode ``client_id``, ``client_secret``, ``username`` and ``password`` "
-                        + "in the Basic authorization request. "
-                        + "If set to ``header``, the credentials are encoded as an "
-                        + "``Authorization: Basic <base-64 encoded client_id:client_secret>`` HTTP header. "
-                        + "If set to ``url``, then ``client_id`` and ``client_secret`` "
-                        + "are sent as URL encoded parameters. Default is ``header``.",
-                CONNECTION_GROUP,
-                groupCounter++,
-                ConfigDef.Width.LONG,
-                BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG,
-                List.of(BASIC_ACCESS_TOKEN_URL_CONFIG, BASIC_CLIENT_ID_CONFIG, BASIC_CLIENT_SECRET_CONFIG,
-                        BASIC_USERNAME_CONFIG, BASIC_PASSWORD_CONFIG,
-                        BASIC_CLIENT_SCOPE_CONFIG, BASIC_RESPONSE_TOKEN_PROPERTY_CONFIG)
-        );
         configDef.define(
                 BASIC_CLIENT_SCOPE_CONFIG,
                 ConfigDef.Type.STRING,
@@ -673,29 +590,7 @@ public final class HttpSinkConfig extends AbstractConfig {
                 ConfigDef.Width.LONG,
                 BASIC_CLIENT_SCOPE_CONFIG,
                 List.of(BASIC_ACCESS_TOKEN_URL_CONFIG, BASIC_CLIENT_ID_CONFIG, BASIC_CLIENT_SECRET_CONFIG,
-                        BASIC_USERNAME_CONFIG, BASIC_PASSWORD_CONFIG,
-                        BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG, BASIC_RESPONSE_TOKEN_PROPERTY_CONFIG)
-        );
-        configDef.define(
-                BASIC_RESPONSE_TOKEN_PROPERTY_CONFIG,
-                ConfigDef.Type.STRING,
-                "access_token",
-                new ConfigDef.NonEmptyStringWithoutControlChars() {
-                    @Override
-                    public String toString() {
-                        return "Basic Auth response token";
-                    }
-                },
-                ConfigDef.Importance.LOW,
-                "The name of the JSON property containing the access token returned "
-                        + "by the Basic Auth provider. Default value is ``access_token``.",
-                CONNECTION_GROUP,
-                groupCounter++,
-                ConfigDef.Width.LONG,
-                BASIC_RESPONSE_TOKEN_PROPERTY_CONFIG,
-                List.of(BASIC_ACCESS_TOKEN_URL_CONFIG, BASIC_CLIENT_ID_CONFIG, BASIC_CLIENT_SECRET_CONFIG,
-                        BASIC_USERNAME_CONFIG, BASIC_PASSWORD_CONFIG,
-                        BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG, BASIC_CLIENT_SCOPE_CONFIG)
+                        BASIC_USERNAME_CONFIG, BASIC_PASSWORD_CONFIG)
         );
     }
 
@@ -948,7 +843,7 @@ public final class HttpSinkConfig extends AbstractConfig {
     }
 
     private void validateBasicAuthConfiguration() {
-        Stream.of(BASIC_ACCESS_TOKEN_URL_CONFIG, BASIC_GRANT_TYPE_PROP_CONFIG, BASIC_GRANT_TYPE_CONFIG,
+        Stream.of(BASIC_ACCESS_TOKEN_URL_CONFIG,
                   BASIC_CLIENT_ID_PROP_CONFIG, BASIC_CLIENT_ID_CONFIG, BASIC_CLIENT_SECRET_PROP_CONFIG,
                   BASIC_USERNAME_PROP_CONFIG, BASIC_USERNAME_CONFIG, BASIC_PASSWORD_PROP_CONFIG)
               .filter(configKey -> getString(configKey) == null || getString(configKey).isBlank())
@@ -1097,18 +992,6 @@ public final class HttpSinkConfig extends AbstractConfig {
         return getString(OAUTH2_RESPONSE_TOKEN_PROPERTY_CONFIG);
     }
 
-
-
-
-    
-    public final String basicAuthGrantTypeProperty() {
-        return getString(BASIC_GRANT_TYPE_PROP_CONFIG);
-    }
-
-    public final String basicAuthGrantType() {
-        return getString(BASIC_GRANT_TYPE_CONFIG);
-    }
-
     public final String basicAuthClientIdProperty() {
         return getString(BASIC_CLIENT_ID_PROP_CONFIG);
     }
@@ -1141,16 +1024,8 @@ public final class HttpSinkConfig extends AbstractConfig {
         return getPassword(BASIC_PASSWORD_CONFIG);
     }
 
-    public final BasicAuthAuthorizationMode basicAuthAuthorizationMode() {
-        return BasicAuthAuthorizationMode.valueOf(getString(BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG).toUpperCase());
-    }
-
     public final String basicAuthClientScope() {
         return getString(BASIC_CLIENT_SCOPE_CONFIG);
-    }
-
-    public final String basicAuthResponseTokenProperty() {
-        return getString(BASIC_RESPONSE_TOKEN_PROPERTY_CONFIG);
     }
 
     public final boolean hasProxy() {

--- a/src/main/java/io/aiven/kafka/connect/http/config/HttpSinkConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/http/config/HttpSinkConfig.java
@@ -614,7 +614,7 @@ public final class HttpSinkConfig extends AbstractConfig {
                         BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG,
                         BASIC_CLIENT_SCOPE_CONFIG, BASIC_RESPONSE_TOKEN_PROPERTY_CONFIG)
         );
-        
+
         configDef.define(
                 BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG,
                 ConfigDef.Type.STRING,
@@ -642,7 +642,8 @@ public final class HttpSinkConfig extends AbstractConfig {
                     }
                 },
                 ConfigDef.Importance.MEDIUM,
-                "Specifies how to encode ``client_id``, ``client_secret``, ``username`` and ``password`` in the Basic authorization request. "
+                "Specifies how to encode ``client_id``, ``client_secret``, ``username`` and ``password`` "
+                        + "in the Basic authorization request. "
                         + "If set to ``header``, the credentials are encoded as an "
                         + "``Authorization: Basic <base-64 encoded client_id:client_secret>`` HTTP header. "
                         + "If set to ``url``, then ``client_id`` and ``client_secret`` "
@@ -652,7 +653,7 @@ public final class HttpSinkConfig extends AbstractConfig {
                 ConfigDef.Width.LONG,
                 BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG,
                 List.of(BASIC_ACCESS_TOKEN_URL_CONFIG, BASIC_CLIENT_ID_CONFIG, BASIC_CLIENT_SECRET_CONFIG,
-                        BASIC_USERNAME_CONF, BASIC_PASSWORD_CONF,
+                        BASIC_USERNAME_CONFIG, BASIC_PASSWORD_CONFIG,
                         BASIC_CLIENT_SCOPE_CONFIG, BASIC_RESPONSE_TOKEN_PROPERTY_CONFIG)
         );
         configDef.define(
@@ -696,7 +697,6 @@ public final class HttpSinkConfig extends AbstractConfig {
                         BASIC_USERNAME_CONFIG, BASIC_PASSWORD_CONFIG,
                         BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG, BASIC_CLIENT_SCOPE_CONFIG)
         );
-        
     }
 
     private static void addBatchingConfigGroup(final ConfigDef configDef) {
@@ -903,8 +903,8 @@ public final class HttpSinkConfig extends AbstractConfig {
                 break;
             case OAUTH2: validateOAuth2Configuration();
                 break;
-            case BASIC: validateOBasicAuthConfiguration();
-                break;                
+            case BASIC: validateBasicAuthConfiguration();
+                break;
             case NONE:
                 if (headerAuthorization() != null && !headerAuthorization().isBlank()) {
                     throw new ConfigException(
@@ -1049,6 +1049,10 @@ public final class HttpSinkConfig extends AbstractConfig {
         return toURI(OAUTH2_ACCESS_TOKEN_URL_CONFIG);
     }
 
+    public final URI basicAuthAccessTokenUri() {
+        return toURI(BASIC_ACCESS_TOKEN_URL_CONFIG);
+    }
+
     private URI toURI(final String propertyName) {
         try {
             return new URL(getString(propertyName)).toURI();
@@ -1093,7 +1097,51 @@ public final class HttpSinkConfig extends AbstractConfig {
         return getString(OAUTH2_RESPONSE_TOKEN_PROPERTY_CONFIG);
     }
 
-    public final basicAuthAuthorizationMode basicAuthAuthorizationMode() {
+
+
+
+    
+    public final String basicAuthGrantTypeProperty() {
+        return getString(BASIC_GRANT_TYPE_PROP_CONFIG);
+    }
+
+    public final String basicAuthGrantType() {
+        return getString(BASIC_GRANT_TYPE_CONFIG);
+    }
+
+    public final String basicAuthClientIdProperty() {
+        return getString(BASIC_CLIENT_ID_PROP_CONFIG);
+    }
+
+    public final String basicAuthClientId() {
+        return getString(BASIC_CLIENT_ID_CONFIG);
+    }
+
+    public final String basicAuthClientSecretProperty() {
+        return getString(BASIC_CLIENT_SECRET_PROP_CONFIG);
+    }
+
+    public final Password basicAuthClientSecret() {
+        return getPassword(BASIC_CLIENT_SECRET_CONFIG);
+    }
+
+    public final String basicAuthUsernameProperty() {
+        return getString(BASIC_USERNAME_PROP_CONFIG);
+    }
+
+    public final String basicAuthUsername() {
+        return getString(BASIC_USERNAME_CONFIG);
+    }
+
+    public final String basicAuthPasswordProperty() {
+        return getString(BASIC_PASSWORD_PROP_CONFIG);
+    }
+
+    public final Password basicAuthPassword() {
+        return getPassword(BASIC_PASSWORD_CONFIG);
+    }
+
+    public final BasicAuthAuthorizationMode basicAuthAuthorizationMode() {
         return BasicAuthAuthorizationMode.valueOf(getString(BASIC_CLIENT_AUTHORIZATION_MODE_CONFIG).toUpperCase());
     }
 

--- a/src/main/java/io/aiven/kafka/connect/http/sender/AbstractHttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/AbstractHttpSender.java
@@ -71,7 +71,7 @@ abstract class AbstractHttpSender {
                 try {
                     final var response =
                             httpClient.send(requestBuilderWithPayload.build(), HttpResponse.BodyHandlers.ofString());
-                    log.debug("Server replied with status code {} and body {}", response.statusCode(), response.body());
+                    log.info("Server replied with status code {} and body {}", response.statusCode(), response.body());
                     // Handle the response
                     httpResponseHandler.onResponse(response, remainingRetries);
                     return response;

--- a/src/main/java/io/aiven/kafka/connect/http/sender/AbstractHttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/AbstractHttpSender.java
@@ -71,12 +71,12 @@ abstract class AbstractHttpSender {
                 try {
                     final var response =
                             httpClient.send(requestBuilderWithPayload.build(), HttpResponse.BodyHandlers.ofString());
-                    log.info("Server replied with status code {} and body {}", response.statusCode(), response.body());
+                    log.debug("Server replied with status code {} and body {}", response.statusCode(), response.body());
                     // Handle the response
                     httpResponseHandler.onResponse(response, remainingRetries);
                     return response;
                 } catch (final IOException e) {
-                    log.info("Sending failed, will retry in {} ms ({} retries remain) by {}",
+                    log.debug("Sending failed, will retry in {} ms ({} retries remain) by {}",
                              config.retryBackoffMs(),
                              remainingRetries,
                              e);

--- a/src/main/java/io/aiven/kafka/connect/http/sender/AbstractHttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/AbstractHttpSender.java
@@ -73,7 +73,7 @@ abstract class AbstractHttpSender {
                             httpClient.send(requestBuilderWithPayload.build(), HttpResponse.BodyHandlers.ofString());
                     log.debug("Server replied with status code {} and body {}", response.statusCode(), response.body());
                     // Handle the response
-                    httpResponseHandler.onResponse(response, remainingRetries);
+                    httpResponseHandler.onResponse(response, remainingRetries, config);
                     return response;
                 } catch (final IOException e) {
                     log.debug("Sending failed, will retry in {} ms ({} retries remain) by {}",

--- a/src/main/java/io/aiven/kafka/connect/http/sender/AbstractHttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/AbstractHttpSender.java
@@ -93,6 +93,10 @@ abstract class AbstractHttpSender {
             msgError = "Sending failed and no retries remain, stopping";
         }
         log.error(msgError);
+        // At this point all retries are exhausted.
+        // We intentionally propagate the last encountered error message (msgError),
+        // instead of a generic failure message, to preserve the real root cause
+        // (e.g. HTTP status codes, remote errors) for observability and debugging.
         throw new ConnectException(msgError);
     }
 

--- a/src/main/java/io/aiven/kafka/connect/http/sender/BasicAuthAccessTokenHttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/BasicAuthAccessTokenHttpSender.java
@@ -1,0 +1,83 @@
+package io.aiven.kafka.connect.http.sender;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Objects;
+
+import io.aiven.kafka.connect.http.config.HttpSinkConfig;
+import io.aiven.kafka.connect.http.config.BasicAuthAuthorizationMode;
+import io.aiven.kafka.connect.http.sender.request.BasicAuthAccessTokenRequestForm;
+
+import static io.aiven.kafka.connect.http.config.BasicAuthAuthorizationMode.HEADER;
+
+class BasicAuthAccessTokenHttpSender extends AbstractHttpSender implements HttpSender {
+
+    BasicAuthAccessTokenHttpSender(final HttpSinkConfig config, final HttpClient httpClient) {
+        super(config, new AccessTokenHttpRequestBuilder(), httpClient);
+    }
+
+    HttpResponse<String> call() {
+        final BasicAuthAccessTokenRequestForm.Builder formBuilder = BasicAuthAccessTokenRequestForm
+            .newBuilder()
+            .withGrantTypeProperty(config.oauth2GrantTypeProperty())
+            .withGrantType(config.oauth2GrantType())
+            .withScope(config.oauth2ClientScope());
+
+        if (config.BasicAuthorizationMode() == BasicAuthAuthorizationMode.URL) {
+            formBuilder
+                .withClientIdProperty(config.basicAuthClientIdProperty())
+                .withClientId(config.basicAuthClientId())
+                .withClientSecretProperty(config.basicAuthClientSecretProperty())
+                .withClientSecret(config
+                    .basicAuthClientSecret()
+                    .value())
+                .withUsernameProperty(config.basicAuthUsernameProperty())
+                .withUsername(config.basicAuthUsername())
+                .withPasswordProperty(config.basicAuthPasswordProperty())
+                .withPassword(config
+                    .basicAuthPassword()
+                    .value());
+        }
+        return super.send(formBuilder
+            .build()
+            .toBodyString());
+    }
+
+    private static class AccessTokenHttpRequestBuilder implements HttpRequestBuilder {
+
+        static final String HEADER_CONTENT_TYPE_FORM = "application/x-www-form-urlencoded";
+
+        protected AccessTokenHttpRequestBuilder() {
+        }
+
+        @Override
+        public HttpRequest.Builder build(final HttpSinkConfig config) {
+            final var builder = HttpRequest
+                .newBuilder(Objects.requireNonNull(config.oauth2AccessTokenUri()))
+                .timeout(Duration.ofSeconds(config.httpTimeout()))
+                .header(HEADER_CONTENT_TYPE, HEADER_CONTENT_TYPE_FORM);
+            if (config.oauth2AuthorizationMode() == HEADER) {
+                addClientIdAndSecretInRequestHeader(config, builder);
+            }
+            return builder;
+        }
+
+        private void addClientIdAndSecretInRequestHeader(
+            final HttpSinkConfig config, final HttpRequest.Builder builder
+        ) {
+            final var clientAndSecretBytes = (config.oauth2ClientId() + ":" + config
+                .oauth2ClientSecret()
+                .value()).getBytes(StandardCharsets.UTF_8);
+            final var clientAndSecretAuthHeader = "Basic " + Base64
+                .getEncoder()
+                .encodeToString(clientAndSecretBytes);
+            builder.header(HEADER_AUTHORIZATION, clientAndSecretAuthHeader);
+        }
+
+    }
+
+}

--- a/src/main/java/io/aiven/kafka/connect/http/sender/BasicAuthAccessTokenHttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/BasicAuthAccessTokenHttpSender.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Aiven Oy and http-connector-for-apache-kafka project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.aiven.kafka.connect.http.sender;
 
 import java.net.http.HttpClient;
@@ -8,8 +24,8 @@ import java.time.Duration;
 import java.util.Base64;
 import java.util.Objects;
 
-import io.aiven.kafka.connect.http.config.HttpSinkConfig;
 import io.aiven.kafka.connect.http.config.BasicAuthAuthorizationMode;
+import io.aiven.kafka.connect.http.config.HttpSinkConfig;
 import io.aiven.kafka.connect.http.sender.request.BasicAuthAccessTokenRequestForm;
 
 import static io.aiven.kafka.connect.http.config.BasicAuthAuthorizationMode.HEADER;
@@ -27,7 +43,7 @@ class BasicAuthAccessTokenHttpSender extends AbstractHttpSender implements HttpS
             .withGrantType(config.oauth2GrantType())
             .withScope(config.oauth2ClientScope());
 
-        if (config.BasicAuthorizationMode() == BasicAuthAuthorizationMode.URL) {
+        if (config.basicAuthAuthorizationMode() == BasicAuthAuthorizationMode.URL) {
             formBuilder
                 .withClientIdProperty(config.basicAuthClientIdProperty())
                 .withClientId(config.basicAuthClientId())
@@ -60,7 +76,7 @@ class BasicAuthAccessTokenHttpSender extends AbstractHttpSender implements HttpS
                 .newBuilder(Objects.requireNonNull(config.oauth2AccessTokenUri()))
                 .timeout(Duration.ofSeconds(config.httpTimeout()))
                 .header(HEADER_CONTENT_TYPE, HEADER_CONTENT_TYPE_FORM);
-            if (config.oauth2AuthorizationMode() == HEADER) {
+            if (config.basicAuthAuthorizationMode() == HEADER) {
                 addClientIdAndSecretInRequestHeader(config, builder);
             }
             return builder;

--- a/src/main/java/io/aiven/kafka/connect/http/sender/BasicAuthAccessTokenHttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/BasicAuthAccessTokenHttpSender.java
@@ -19,18 +19,16 @@ package io.aiven.kafka.connect.http.sender;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.Base64;
 import java.util.Objects;
 
-import io.aiven.kafka.connect.http.config.BasicAuthAuthorizationMode;
 import io.aiven.kafka.connect.http.config.HttpSinkConfig;
 import io.aiven.kafka.connect.http.sender.request.BasicAuthAccessTokenRequestForm;
 
-import static io.aiven.kafka.connect.http.config.BasicAuthAuthorizationMode.HEADER;
-
 class BasicAuthAccessTokenHttpSender extends AbstractHttpSender implements HttpSender {
+
+    private static final String GRANT_TYPE_PROPERTY = "grant_type";
+    private static final String GRANT_TYPE = "password";
 
     BasicAuthAccessTokenHttpSender(final HttpSinkConfig config, final HttpClient httpClient) {
         super(config, new AccessTokenHttpRequestBuilder(), httpClient);
@@ -39,25 +37,27 @@ class BasicAuthAccessTokenHttpSender extends AbstractHttpSender implements HttpS
     HttpResponse<String> call() {
         final BasicAuthAccessTokenRequestForm.Builder formBuilder = BasicAuthAccessTokenRequestForm
             .newBuilder()
-            .withGrantTypeProperty(config.oauth2GrantTypeProperty())
-            .withGrantType(config.oauth2GrantType())
-            .withScope(config.oauth2ClientScope());
+            .withGrantTypeProperty(GRANT_TYPE_PROPERTY)
+            .withGrantType(GRANT_TYPE)
+            .withScope(config.basicAuthClientScope());
 
-        if (config.basicAuthAuthorizationMode() == BasicAuthAuthorizationMode.URL) {
+        formBuilder
+            .withClientIdProperty(config.basicAuthClientIdProperty())
+            .withClientId(config.basicAuthClientId())
+            .withUsernameProperty(config.basicAuthUsernameProperty())
+            .withUsername(config.basicAuthUsername())
+            .withPasswordProperty(config.basicAuthPasswordProperty())
+            .withPassword(config
+                          .basicAuthPassword()
+                          .value());
+
+        final var secret = config.basicAuthClientSecret();
+        if (secret != null && secret.value() != null && !secret.value().isBlank()) {
             formBuilder
-                .withClientIdProperty(config.basicAuthClientIdProperty())
-                .withClientId(config.basicAuthClientId())
                 .withClientSecretProperty(config.basicAuthClientSecretProperty())
-                .withClientSecret(config
-                    .basicAuthClientSecret()
-                    .value())
-                .withUsernameProperty(config.basicAuthUsernameProperty())
-                .withUsername(config.basicAuthUsername())
-                .withPasswordProperty(config.basicAuthPasswordProperty())
-                .withPassword(config
-                    .basicAuthPassword()
-                    .value());
+                .withClientSecret(secret.value());
         }
+
         return super.send(formBuilder
             .build()
             .toBodyString());
@@ -73,25 +73,10 @@ class BasicAuthAccessTokenHttpSender extends AbstractHttpSender implements HttpS
         @Override
         public HttpRequest.Builder build(final HttpSinkConfig config) {
             final var builder = HttpRequest
-                .newBuilder(Objects.requireNonNull(config.oauth2AccessTokenUri()))
+                .newBuilder(Objects.requireNonNull(config.basicAuthAccessTokenUri()))
                 .timeout(Duration.ofSeconds(config.httpTimeout()))
                 .header(HEADER_CONTENT_TYPE, HEADER_CONTENT_TYPE_FORM);
-            if (config.basicAuthAuthorizationMode() == HEADER) {
-                addClientIdAndSecretInRequestHeader(config, builder);
-            }
             return builder;
-        }
-
-        private void addClientIdAndSecretInRequestHeader(
-            final HttpSinkConfig config, final HttpRequest.Builder builder
-        ) {
-            final var clientAndSecretBytes = (config.oauth2ClientId() + ":" + config
-                .oauth2ClientSecret()
-                .value()).getBytes(StandardCharsets.UTF_8);
-            final var clientAndSecretAuthHeader = "Basic " + Base64
-                .getEncoder()
-                .encodeToString(clientAndSecretBytes);
-            builder.header(HEADER_AUTHORIZATION, clientAndSecretAuthHeader);
         }
 
     }

--- a/src/main/java/io/aiven/kafka/connect/http/sender/BasicAuthHttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/BasicAuthHttpSender.java
@@ -54,7 +54,8 @@ class BasicAuthHttpSender extends AbstractHttpSender implements HttpSender {
     ) {
         final HttpResponseHandler composedHandler = (response, remainingRetries) -> {
             final int status = response.statusCode();
-            LOGGER.info("response status{}", status);
+            LOGGER.info("Server replied with status code {} and body {}",
+                       status, response.body());
 
             // If we got Unauthorized (or Forbidden) and we still have retries left,
             // renew the access token and force AbstractHttpSender to retry by throwing IOException.

--- a/src/main/java/io/aiven/kafka/connect/http/sender/BasicAuthHttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/BasicAuthHttpSender.java
@@ -70,7 +70,7 @@ class BasicAuthHttpSender extends AbstractHttpSender implements HttpSender {
 
         private final HttpSinkConfig config;
         private final BasicAuthAccessTokenHttpSender basicAuthAccessTokenHttpSender;
-
+        private static final String ACCESS_TOKEN_FIELD = "access_token";
         private String accessToken;
 
         BasicAuthHttpRequestBuilder(
@@ -126,13 +126,13 @@ class BasicAuthHttpSender extends AbstractHttpSender implements HttpSender {
         private String buildAccessTokenAuthHeader(final String basicAuthResponseBody) throws JsonProcessingException {
             final var accessTokenResponse =
                 OBJECT_MAPPER.readValue(basicAuthResponseBody, new TypeReference<Map<String, String>>() {});
-            if (!accessTokenResponse.containsKey(config.basicAuthResponseTokenProperty())) {
+            if (!accessTokenResponse.containsKey(ACCESS_TOKEN_FIELD)) {
                 throw new ConnectException("Couldn't find access token property "
-                                           + config.basicAuthResponseTokenProperty()
+                                           + ACCESS_TOKEN_FIELD
                                            + " in response properties: " + accessTokenResponse.keySet());
             }
             final var tokenType = accessTokenResponse.getOrDefault("token_type", "Bearer");
-            final var accessToken = accessTokenResponse.get(config.basicAuthResponseTokenProperty());
+            final var accessToken = accessTokenResponse.get(ACCESS_TOKEN_FIELD);
             return String.format("%s %s", tokenType, accessToken);
         }
 

--- a/src/main/java/io/aiven/kafka/connect/http/sender/BasicAuthHttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/BasicAuthHttpSender.java
@@ -36,6 +36,8 @@ import org.slf4j.LoggerFactory;
 
 class BasicAuthHttpSender extends AbstractHttpSender implements HttpSender {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(BasicAuthHttpSender.class);
+
     BasicAuthHttpSender(
         final HttpSinkConfig config,
         final HttpClient client,
@@ -52,6 +54,7 @@ class BasicAuthHttpSender extends AbstractHttpSender implements HttpSender {
     ) {
         final HttpResponseHandler composedHandler = (response, remainingRetries) -> {
             final int status = response.statusCode();
+            LOGGER.info("response status{}", status);
 
             // If we got Unauthorized (or Forbidden) and we still have retries left,
             // renew the access token and force AbstractHttpSender to retry by throwing IOException.
@@ -73,7 +76,8 @@ class BasicAuthHttpSender extends AbstractHttpSender implements HttpSender {
         private final HttpSinkConfig config;
         private final BasicAuthAccessTokenHttpSender basicAuthAccessTokenHttpSender;
         private static final String ACCESS_TOKEN_FIELD = "access_token";
-        private String accessToken;
+        private volatile String accessToken;
+        private final Object tokenLock = new Object();
 
         BasicAuthHttpRequestBuilder(
             final HttpSinkConfig config,
@@ -97,31 +101,47 @@ class BasicAuthHttpSender extends AbstractHttpSender implements HttpSender {
          * @param requestBuilder the request builder used to call the protected URI
          */
         void renewAccessToken(final HttpRequest.Builder requestBuilder) {
-            this.accessToken = null;
+            synchronized (tokenLock) {
+                this.accessToken = null;
+            }
+            LOGGER.info("renewAccessToken using BasicAuth for URI: {} and Client ID: {}",
+                        config.basicAuthAccessTokenUri(),
+                        config.basicAuthClientId());
             requestBuilder.setHeader(HttpRequestBuilder.HEADER_AUTHORIZATION, this.requestAccessToken());
         }
-        
+
         /**
          * Retrieves the current access token or requests it if none is defined
          *
          * @return an access token
          */
         private String requestAccessToken() {
-            // Re-use the access token if it's already defined
-            if (this.accessToken != null) {
-                return this.accessToken;
-            }
-            LOGGER.info("Configure BasicAuth for URI: {} and Client ID: {}", config.basicAuthAccessTokenUri(),
+            LOGGER.info("requestAccessToken using BasicAuth for URI: {} and Client ID: {}",
+                        config.basicAuthAccessTokenUri(),
                         config.basicAuthClientId());
-            try {
-                // Whenever the access token is null (not initialized yet or expired), call the AccessTokenHttpSender
-                // implementation to request one
-                final var response = basicAuthAccessTokenHttpSender.call();
-                accessToken = buildAccessTokenAuthHeader(response.body());
-            } catch (final IOException e) {
-                throw new ConnectException("Couldn't get BasicAuth access token", e);
+            String token = this.accessToken;
+            if (token != null) {
+                return token;
             }
-            return accessToken;
+
+            synchronized (tokenLock) {
+                token = this.accessToken;
+                if (token != null) {
+                    return token;
+                }
+                LOGGER.info("Requesting BasicAuth token from URI: {} for clientId: {}",
+                             config.basicAuthAccessTokenUri(), config.basicAuthClientId());
+                try {
+                    // Whenever the access token is null (not initialized yet or expired),
+                    // call the AccessTokenHttpSender implementation to request one
+                    final var response = basicAuthAccessTokenHttpSender.call();
+                    token = buildAccessTokenAuthHeader(response.body());
+                    this.accessToken = token;
+                    return token;
+                } catch (final IOException e) {
+                    throw new ConnectException("Couldn't get BasicAuth access token", e);
+                }
+            }
         }
 
         private String buildAccessTokenAuthHeader(final String basicAuthResponseBody) throws JsonProcessingException {

--- a/src/main/java/io/aiven/kafka/connect/http/sender/BasicAuthHttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/BasicAuthHttpSender.java
@@ -1,0 +1,87 @@
+package io.aiven.kafka.connect.http.sender;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest.Builder;
+
+import io.aiven.kafka.connect.http.config.HttpSinkConfig;
+import io.aiven.kafka.connect.http.sender.DefaultHttpSender.DefaultHttpRequestBuilder;
+
+class BasicAuthHttpSender extends AbstractHttpSender implements HttpSender {
+
+    BasicAuthHttpSender(
+        final HttpSinkConfig config,
+        final HttpClient client,
+        final BasicAuthAccessTokenHttpSender basicAuthAccessTokenHttpSender
+    ) {
+        super(config, new BasicAuthHttpRequestBuilder(), basicAuthAccessTokenHttpSender, client);
+    }
+
+    private static class BasicAuthHttpRequestBuilder extends DefaultHttpRequestBuilder {
+
+        BasicAuthHttpRequestBuilder(
+            final HttpSinkConfig config,
+            final BasicAuthAccessTokenHttpSender basicAuthccessTokenHttpSender
+        ) {
+            this.config = config;
+            this.basicAuthAccessTokenHttpSender = basicAuthAccessTokenHttpSender;
+        }
+
+        
+        @Override
+        public Builder build(final HttpSinkConfig config) {
+            return super
+                .build(config)
+                .header(HEADER_AUTHORIZATION, requestAccessToken());
+        }
+
+
+        /**
+         * When expired, reinitialize the current token, request a new one and update the request builder
+         *
+         * @param requestBuilder the request builder used to call the protected URI
+         */
+        void renewAccessToken(final HttpRequest.Builder requestBuilder) {
+            this.accessToken = null;
+            requestBuilder.setHeader(HttpRequestBuilder.HEADER_AUTHORIZATION, this.requestAccessToken());
+        }
+        
+        /**
+         * Retrieves the current access token or requests it if none is defined
+         *
+         * @return an access token
+         */
+        private String requestAccessToken() {
+            // Re-use the access token if it's already defined
+            if (this.accessToken != null) {
+                return this.accessToken;
+            }
+            LOGGER.info("Configure BasicAuth for URI: {} and Client ID: {}", config.basicAuthTokenUri()(),
+                config.basicAuthClientId());
+            try {
+                // Whenever the access token is null (not initialized yet or expired), call the AccessTokenHttpSender
+                // implementation to request one
+                final var response = basicAuthAccessTokenHttpSender.call();
+                accessToken = buildAccessTokenAuthHeader(response.body());
+            } catch (final IOException e) {
+                throw new ConnectException("Couldn't get BasicAuth access token", e);
+            }
+            return accessToken;
+        }
+
+        private String buildAccessTokenAuthHeader(final String basicAuthResponseBody) throws JsonProcessingException {
+            final var accessTokenResponse =
+                OBJECT_MAPPER.readValue(basicAuthResponseBody, new TypeReference<Map<String, String>>() {});
+            if (!accessTokenResponse.containsKey(config.basicAuthResponseTokenProperty())) {
+                throw new ConnectException("Couldn't find access token property " + config.basicAuthResponseTokenProperty()
+                                           + " in response properties: " + accessTokenResponse.keySet());
+            }
+            final var tokenType = accessTokenResponse.getOrDefault("token_type", "Bearer");
+            final var accessToken = accessTokenResponse.get(config.basicAuthResponseTokenProperty());
+            return String.format("%s %s", tokenType, accessToken);
+        }
+
+        
+        
+    }
+
+}

--- a/src/main/java/io/aiven/kafka/connect/http/sender/BasicAuthHttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/BasicAuthHttpSender.java
@@ -1,10 +1,38 @@
+/*
+ * Copyright 2023 Aiven Oy and http-connector-for-apache-kafka project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.aiven.kafka.connect.http.sender;
 
+import java.io.IOException;
 import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.Builder;
+import java.net.http.HttpResponse;
+import java.util.Map;
+
+import org.apache.kafka.connect.errors.ConnectException;
 
 import io.aiven.kafka.connect.http.config.HttpSinkConfig;
 import io.aiven.kafka.connect.http.sender.DefaultHttpSender.DefaultHttpRequestBuilder;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class BasicAuthHttpSender extends AbstractHttpSender implements HttpSender {
 
@@ -13,14 +41,41 @@ class BasicAuthHttpSender extends AbstractHttpSender implements HttpSender {
         final HttpClient client,
         final BasicAuthAccessTokenHttpSender basicAuthAccessTokenHttpSender
     ) {
-        super(config, new BasicAuthHttpRequestBuilder(), basicAuthAccessTokenHttpSender, client);
+        super(config, new BasicAuthHttpRequestBuilder(config, basicAuthAccessTokenHttpSender), client);
+    }
+
+    @Override
+    protected HttpResponse<String> sendWithRetries(
+        final Builder requestBuilder, final HttpResponseHandler originHttpResponseHandler, final int retries
+    ) {
+        // This handler allows to request a new access token if a 401 occurs, meaning the session might be expired
+        final HttpResponseHandler handler = (response, remainingRetries) -> {
+            // If the response has a 401 error and we have retries left, we attempt to renew the session
+            if (response.statusCode() == 401 && remainingRetries > 0) {
+                // Update the request builder with the new access token
+                ((BasicAuthHttpRequestBuilder) this.httpRequestBuilder).renewAccessToken(requestBuilder);
+                // Retry the call and decrease the retries counter to avoid looping on token renewal
+                this.sendWithRetries(requestBuilder, originHttpResponseHandler, remainingRetries - 1);
+            } else {
+                originHttpResponseHandler.onResponse(response, remainingRetries);
+            }
+        };
+        return super.sendWithRetries(requestBuilder, handler, retries);
     }
 
     private static class BasicAuthHttpRequestBuilder extends DefaultHttpRequestBuilder {
 
+        private static final Logger LOGGER = LoggerFactory.getLogger(BasicAuthHttpRequestBuilder.class);
+        private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+        private final HttpSinkConfig config;
+        private final BasicAuthAccessTokenHttpSender basicAuthAccessTokenHttpSender;
+
+        private String accessToken;
+
         BasicAuthHttpRequestBuilder(
             final HttpSinkConfig config,
-            final BasicAuthAccessTokenHttpSender basicAuthccessTokenHttpSender
+            final BasicAuthAccessTokenHttpSender basicAuthAccessTokenHttpSender
         ) {
             this.config = config;
             this.basicAuthAccessTokenHttpSender = basicAuthAccessTokenHttpSender;
@@ -55,8 +110,8 @@ class BasicAuthHttpSender extends AbstractHttpSender implements HttpSender {
             if (this.accessToken != null) {
                 return this.accessToken;
             }
-            LOGGER.info("Configure BasicAuth for URI: {} and Client ID: {}", config.basicAuthTokenUri()(),
-                config.basicAuthClientId());
+            LOGGER.info("Configure BasicAuth for URI: {} and Client ID: {}", config.basicAuthAccessTokenUri(),
+                        config.basicAuthClientId());
             try {
                 // Whenever the access token is null (not initialized yet or expired), call the AccessTokenHttpSender
                 // implementation to request one
@@ -72,7 +127,8 @@ class BasicAuthHttpSender extends AbstractHttpSender implements HttpSender {
             final var accessTokenResponse =
                 OBJECT_MAPPER.readValue(basicAuthResponseBody, new TypeReference<Map<String, String>>() {});
             if (!accessTokenResponse.containsKey(config.basicAuthResponseTokenProperty())) {
-                throw new ConnectException("Couldn't find access token property " + config.basicAuthResponseTokenProperty()
+                throw new ConnectException("Couldn't find access token property "
+                                           + config.basicAuthResponseTokenProperty()
                                            + " in response properties: " + accessTokenResponse.keySet());
             }
             final var tokenType = accessTokenResponse.getOrDefault("token_type", "Bearer");

--- a/src/main/java/io/aiven/kafka/connect/http/sender/BasicAuthHttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/BasicAuthHttpSender.java
@@ -52,7 +52,7 @@ class BasicAuthHttpSender extends AbstractHttpSender implements HttpSender {
         final HttpResponseHandler originHandler,
         final int retries
     ) {
-        final HttpResponseHandler composedHandler = (response, remainingRetries) -> {
+        final HttpResponseHandler composedHandler = (response, remainingRetries, config) -> {
             final int status = response.statusCode();
             LOGGER.info("Server replied with status code {} and body {}",
                        status, response.body());
@@ -64,7 +64,7 @@ class BasicAuthHttpSender extends AbstractHttpSender implements HttpSender {
                 throw new IOException(status + " received: renewed access token, retrying");
             }
             // Keep existing logic (GraphQL 200 with errors[], >=400, etc.)
-            originHandler.onResponse(response, remainingRetries);
+            originHandler.onResponse(response, remainingRetries, config);
         };
         return super.sendWithRetries(requestBuilder, composedHandler, retries);
     }

--- a/src/main/java/io/aiven/kafka/connect/http/sender/BasicAuthHttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/BasicAuthHttpSender.java
@@ -117,17 +117,15 @@ class BasicAuthHttpSender extends AbstractHttpSender implements HttpSender {
          * @return an access token
          */
         private String requestAccessToken() {
-            LOGGER.info("requestAccessToken using BasicAuth for URI: {} and Client ID: {}",
-                        config.basicAuthAccessTokenUri(),
-                        config.basicAuthClientId());
             String token = this.accessToken;
             if (token != null) {
+                LOGGER.debug("requestAccessToken using current token");
                 return token;
             }
-
             synchronized (tokenLock) {
                 token = this.accessToken;
                 if (token != null) {
+                    LOGGER.debug("requestAccessToken using current token");
                     return token;
                 }
                 LOGGER.info("Requesting BasicAuth token from URI: {} for clientId: {}",

--- a/src/main/java/io/aiven/kafka/connect/http/sender/BasicAuthHttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/BasicAuthHttpSender.java
@@ -46,21 +46,18 @@ class BasicAuthHttpSender extends AbstractHttpSender implements HttpSender {
 
     @Override
     protected HttpResponse<String> sendWithRetries(
-        final Builder requestBuilder, final HttpResponseHandler originHttpResponseHandler, final int retries
+        final Builder requestBuilder,
+        final HttpResponseHandler originHandler,
+        final int retries
     ) {
-        // This handler allows to request a new access token if a 401 occurs, meaning the session might be expired
-        final HttpResponseHandler handler = (response, remainingRetries) -> {
-            // If the response has a 401 error and we have retries left, we attempt to renew the session
-            if (response.statusCode() == 401 && remainingRetries > 0) {
-                // Update the request builder with the new access token
+        final HttpResponseHandler composed = (response, remainingRetries) -> {
+            if ((response.statusCode() == 401 || response.statusCode() == 403) && remainingRetries > 0) {
                 ((BasicAuthHttpRequestBuilder) this.httpRequestBuilder).renewAccessToken(requestBuilder);
-                // Retry the call and decrease the retries counter to avoid looping on token renewal
-                this.sendWithRetries(requestBuilder, originHttpResponseHandler, remainingRetries - 1);
-            } else {
-                originHttpResponseHandler.onResponse(response, remainingRetries);
+                throw new IOException("401 Unauthorized, renewing access token and retrying");
             }
+            originHandler.onResponse(response, remainingRetries);
         };
-        return super.sendWithRetries(requestBuilder, handler, retries);
+        return super.sendWithRetries(requestBuilder, composed, retries);
     }
 
     private static class BasicAuthHttpRequestBuilder extends DefaultHttpRequestBuilder {
@@ -80,7 +77,6 @@ class BasicAuthHttpSender extends AbstractHttpSender implements HttpSender {
             this.config = config;
             this.basicAuthAccessTokenHttpSender = basicAuthAccessTokenHttpSender;
         }
-
         
         @Override
         public Builder build(final HttpSinkConfig config) {

--- a/src/main/java/io/aiven/kafka/connect/http/sender/BasicAuthHttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/BasicAuthHttpSender.java
@@ -50,14 +50,19 @@ class BasicAuthHttpSender extends AbstractHttpSender implements HttpSender {
         final HttpResponseHandler originHandler,
         final int retries
     ) {
-        final HttpResponseHandler composed = (response, remainingRetries) -> {
-            if ((response.statusCode() == 401 || response.statusCode() == 403) && remainingRetries > 0) {
+        final HttpResponseHandler composedHandler = (response, remainingRetries) -> {
+            final int status = response.statusCode();
+
+            // If we got Unauthorized (or Forbidden) and we still have retries left,
+            // renew the access token and force AbstractHttpSender to retry by throwing IOException.
+            if ((status == 401 || status == 403) && remainingRetries > 0) {
                 ((BasicAuthHttpRequestBuilder) this.httpRequestBuilder).renewAccessToken(requestBuilder);
-                throw new IOException("401 Unauthorized, renewing access token and retrying");
+                throw new IOException(status + " received: renewed access token, retrying");
             }
+            // Keep existing logic (GraphQL 200 with errors[], >=400, etc.)
             originHandler.onResponse(response, remainingRetries);
         };
-        return super.sendWithRetries(requestBuilder, composed, retries);
+        return super.sendWithRetries(requestBuilder, composedHandler, retries);
     }
 
     private static class BasicAuthHttpRequestBuilder extends DefaultHttpRequestBuilder {

--- a/src/main/java/io/aiven/kafka/connect/http/sender/HttpResponseHandler.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/HttpResponseHandler.java
@@ -19,6 +19,8 @@ package io.aiven.kafka.connect.http.sender;
 import java.io.IOException;
 import java.net.http.HttpResponse;
 
+import io.aiven.kafka.connect.http.config.HttpSinkConfig;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
@@ -29,10 +31,12 @@ interface HttpResponseHandler {
     Logger LOGGER = LoggerFactory.getLogger(HttpResponseHandler.class);
     final ObjectMapper MAPPER = new ObjectMapper();
 
-    void onResponse(final HttpResponse<String> response, int remainingRetries) throws IOException;
+    void onResponse(final HttpResponse<String> response,
+                    int remainingRetries,
+                    HttpSinkConfig config) throws IOException;
 
-    HttpResponseHandler ON_HTTP_ERROR_RESPONSE_HANDLER = (response, remainingRetries) -> {
-        if (response.statusCode() == 200) {
+    HttpResponseHandler ON_HTTP_ERROR_RESPONSE_HANDLER = (response, remainingRetries, config) -> {
+        if (config.graphqlErrorsAsHttpError() && response.statusCode() == 200) {
             // GraphQL logic: response 200 with errors[] are like 400
             boolean isError = false;
             final Object value = response.body();

--- a/src/main/java/io/aiven/kafka/connect/http/sender/HttpResponseHandler.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/HttpResponseHandler.java
@@ -19,35 +19,34 @@ package io.aiven.kafka.connect.http.sender;
 import java.io.IOException;
 import java.net.http.HttpResponse;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 interface HttpResponseHandler {
 
     Logger LOGGER = LoggerFactory.getLogger(HttpResponseHandler.class);
-    final ObjectMapper mapper = new ObjectMapper();
+    final ObjectMapper MAPPER = new ObjectMapper();
 
     void onResponse(final HttpResponse<String> response, int remainingRetries) throws IOException;
 
     HttpResponseHandler ON_HTTP_ERROR_RESPONSE_HANDLER = (response, remainingRetries) -> {
         if (response.statusCode() == 200) {
             boolean isError = false;
-            Object value = response.body();
+            final Object value = response.body();
             if (value != null) {
                 try {
                     JsonNode root = null;
                     if (value instanceof String) {
-                        root = mapper.readTree((String) value);
+                        root = MAPPER.readTree((String) value);
                     } else {
                         // fallback: serialize value.toString()
-                        root = mapper.readTree(value.toString());
+                        root = MAPPER.readTree(value.toString());
                     }
-                    if (root.has("errors") &&
-                        root.get("errors").isArray() &&
-                        root.get("errors").size() > 0) {
+                    if (root.has("errors")
+                        && root.get("errors").isArray()
+                        && root.get("errors").size() > 0) {
                         isError = true;
                     }
                 } catch (IOException e) {

--- a/src/main/java/io/aiven/kafka/connect/http/sender/HttpResponseHandler.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/HttpResponseHandler.java
@@ -33,6 +33,7 @@ interface HttpResponseHandler {
 
     HttpResponseHandler ON_HTTP_ERROR_RESPONSE_HANDLER = (response, remainingRetries) -> {
         if (response.statusCode() == 200) {
+            // GraphQL logic: response 200 with errors[] are like 400
             boolean isError = false;
             final Object value = response.body();
             if (value != null) {

--- a/src/main/java/io/aiven/kafka/connect/http/sender/HttpSenderFactory.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/HttpSenderFactory.java
@@ -43,6 +43,10 @@ public final class HttpSenderFactory {
                 return new DefaultHttpSender(config, client);
             case STATIC:
                 return new StaticAuthHttpSender(config, client);
+            case BASIC:
+                final BasicAuthAccessTokenHttpSender basicAccessTokenHttpSender =
+                    new BasicAuthAccessTokenHttpSender(config, client);
+                return new BasicAuthHttpSender(config, client, basicAccessTokenHttpSender);
             case OAUTH2:
                 final OAuth2AccessTokenHttpSender oauth2AccessTokenHttpSender =
                     new OAuth2AccessTokenHttpSender(config, client);

--- a/src/main/java/io/aiven/kafka/connect/http/sender/OAuth2HttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/OAuth2HttpSender.java
@@ -49,7 +49,7 @@ class OAuth2HttpSender extends AbstractHttpSender implements HttpSender {
         final Builder requestBuilder, final HttpResponseHandler originHttpResponseHandler, final int retries
     ) {
         // This handler allows to request a new access token if a 401 occurs, meaning the session might be expired
-        final HttpResponseHandler handler = (response, remainingRetries) -> {
+        final HttpResponseHandler handler = (response, remainingRetries, config) -> {
             // If the response has a 401 error and we have retries left, we attempt to renew the session
             if (response.statusCode() == 401 && remainingRetries > 0) {
                 // Update the request builder with the new access token
@@ -57,7 +57,7 @@ class OAuth2HttpSender extends AbstractHttpSender implements HttpSender {
                 // Retry the call and decrease the retries counter to avoid looping on token renewal
                 this.sendWithRetries(requestBuilder, originHttpResponseHandler, remainingRetries - 1);
             } else {
-                originHttpResponseHandler.onResponse(response, remainingRetries);
+                originHttpResponseHandler.onResponse(response, remainingRetries, config);
             }
         };
         return super.sendWithRetries(requestBuilder, handler, retries);

--- a/src/main/java/io/aiven/kafka/connect/http/sender/request/BasicAuthAccessTokenRequestForm.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/request/BasicAuthAccessTokenRequestForm.java
@@ -1,0 +1,192 @@
+package io.aiven.kafka.connect.http.sender.request;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+public class BasicAuthAccessTokenRequestForm {
+
+    private static final String SCOPE = "scope";
+
+    private final String grantTypeProperty;
+    private final String grantType;
+
+    private final String scope;
+    private final String clientIdProperty;
+    private final String clientId;
+
+    private final String clientSecretProperty;
+    private final String clientSecret;
+
+    private final String usernameProperty;
+    private final String username;
+
+    private final String passwordProperty;
+    private final String password;
+
+    private BasicAuthAccessTokenRequestForm(
+        final String grantTypeProperty,
+        final String grantType,
+        final String scope,
+        final String clientIdProperty,
+        final String clientId,
+        final String clientSecretProperty,
+        final String clientSecret,
+        final String usernameProperty;
+        final String username;
+        final String passwordProperty;
+        final String password;        
+    ) {
+        this.grantTypeProperty = grantTypeProperty;
+        this.grantType = grantType;
+        this.scope = scope;
+        this.clientIdProperty = clientIdProperty;
+        this.clientId = clientId;
+        this.clientSecretProperty = clientSecretProperty;
+        this.clientSecret = clientSecret;
+        this.usernameProperty = usernameProperty;
+        this.username = username;
+        this.passwordProperty = passwordProperty;
+        this.password = password;
+    }
+
+    public String toBodyString() {
+        final StringJoiner stringJoiner = new StringJoiner("&").add(encodeNameAndValue(grantTypeProperty, grantType));
+        if (scope != null) {
+            stringJoiner.add(encodeNameAndValue(SCOPE, scope));
+        }
+        if (clientId != null && clientSecret != null) {
+            stringJoiner
+                .add(encodeNameAndValue(clientIdProperty, clientId))
+                .add(encodeNameAndValue(clientSecretProperty, clientSecret));
+        }
+        if (username != null && password != null) {
+            stringJoiner
+                .add(encodeNameAndValue(usernameProperty, username))
+                .add(encodeNameAndValue(passwordProperty, password));
+        }        
+        return stringJoiner.toString();
+    }
+
+    private String encodeNameAndValue(final String name, final String value) {
+        return String.format("%s=%s", encode(name), encode(value));
+    }
+
+    private static String encode(final String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String grantTypeProperty;
+        private String grantType;
+
+        private String scope;
+        private String clientIdProperty;
+        private String clientId;
+
+        private String clientSecretProperty;
+        private String clientSecret;
+
+        private String usernameProperty;
+        private String username;
+
+        private String passwordProperty;
+        private String password;
+
+        private Builder() {
+        }
+
+        public Builder withGrantTypeProperty(final String grantTypeProperty) {
+            this.grantTypeProperty = grantTypeProperty;
+            return this;
+        }
+
+        public Builder withGrantType(final String grantType) {
+            this.grantType = grantType;
+            return this;
+        }
+
+        public Builder withScope(final String scope) {
+            this.scope = scope;
+            return this;
+        }
+
+        public Builder withClientIdProperty(final String clientIdProperty) {
+            this.clientIdProperty = clientIdProperty;
+            return this;
+        }
+
+        public Builder withClientId(final String clientId) {
+            this.clientId = clientId;
+            return this;
+        }
+
+        public Builder withClientSecretProperty(final String clientSecretProperty) {
+            this.clientSecretProperty = clientSecretProperty;
+            return this;
+        }
+
+        public Builder withClientSecret(final String clientSecret) {
+            this.clientSecret = clientSecret;
+            return this;
+        }
+
+        public Builder withUsernameProperty(final String usernameProperty) {
+            this.usernameProperty = usernameProperty;
+            return this;
+        }
+
+        public Builder withUsername(final String username) {
+            this.username = username;
+            return this;
+        }
+
+        public Builder withPasswordProperty(final String passwordProperty) {
+            this.passwordProperty = passwordProperty;
+            return this;
+        }
+
+        public Builder withPassword(final String password) {
+            this.password = password;
+            return this;
+        }        
+
+        public BasicAuthAccessTokenRequestForm build() {
+            Objects.requireNonNull(grantTypeProperty, "The grant type property is required");
+            Objects.requireNonNull(grantType, "The grant type is required");
+
+            // Both of the credential properties need to be set
+            if (clientIdProperty != null || clientSecretProperty != null) {
+                Objects.requireNonNull(clientIdProperty, "The client id property is required");
+                Objects.requireNonNull(clientSecretProperty, "The client secret property is required");
+            }
+            // Both of the credential values need to be set
+            if (clientId != null || clientSecret != null) {
+                Objects.requireNonNull(clientId, "The client id is required");
+                Objects.requireNonNull(clientSecret, "The client secret is required");
+            }
+
+            // Both of the credential properties need to be set
+            if (usernameProperty != null || passwordProperty != null) {
+                Objects.requireNonNull(usernameProperty, "The username property is required");
+                Objects.requireNonNull(passwordProperty, "The password property is required");
+            }
+            // Both of the credential values need to be set
+            if (username != null || password != null) {
+                Objects.requireNonNull(username, "The username is required");
+                Objects.requireNonNull(password, "The password is required");
+            }
+
+            return new BasicAuthAccessTokenRequestForm(
+                                                       grantTypeProperty, grantType, scope, clientIdProperty, clientId, clientSecretProperty, clientSecret, usernameProperty, username, passswordProperty, password);
+        }
+
+    }
+
+}

--- a/src/main/java/io/aiven/kafka/connect/http/sender/request/BasicAuthAccessTokenRequestForm.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/request/BasicAuthAccessTokenRequestForm.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Aiven Oy and http-connector-for-apache-kafka project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.aiven.kafka.connect.http.sender.request;
 
 import java.net.URLEncoder;
@@ -33,10 +49,10 @@ public class BasicAuthAccessTokenRequestForm {
         final String clientId,
         final String clientSecretProperty,
         final String clientSecret,
-        final String usernameProperty;
-        final String username;
-        final String passwordProperty;
-        final String password;        
+        final String usernameProperty,
+        final String username,
+        final String passwordProperty,
+        final String password
     ) {
         this.grantTypeProperty = grantTypeProperty;
         this.grantType = grantType;
@@ -184,7 +200,11 @@ public class BasicAuthAccessTokenRequestForm {
             }
 
             return new BasicAuthAccessTokenRequestForm(
-                                                       grantTypeProperty, grantType, scope, clientIdProperty, clientId, clientSecretProperty, clientSecret, usernameProperty, username, passswordProperty, password);
+                                                       grantTypeProperty, grantType, scope,
+                                                       clientIdProperty, clientId,
+                                                       clientSecretProperty, clientSecret,
+                                                       usernameProperty, username,
+                                                       passwordProperty, password);
         }
 
     }

--- a/src/main/java/io/aiven/kafka/connect/http/sender/request/BasicAuthAccessTokenRequestForm.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/request/BasicAuthAccessTokenRequestForm.java
@@ -21,6 +21,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.StringJoiner;
 
+
+
 public class BasicAuthAccessTokenRequestForm {
 
     private static final String SCOPE = "scope";
@@ -42,29 +44,28 @@ public class BasicAuthAccessTokenRequestForm {
     private final String password;
 
     private BasicAuthAccessTokenRequestForm(
-        final String grantTypeProperty,
-        final String grantType,
+        final PropertyValue grantType,
         final String scope,
-        final String clientIdProperty,
-        final String clientId,
-        final String clientSecretProperty,
-        final String clientSecret,
-        final String usernameProperty,
-        final String username,
-        final String passwordProperty,
-        final String password
+        final PropertyValue clientId,
+        final PropertyValue clientSecret,
+        final PropertyValue username,
+        final PropertyValue password
     ) {
-        this.grantTypeProperty = grantTypeProperty;
-        this.grantType = grantType;
+        this.grantTypeProperty = grantType.property();
+        this.grantType = grantType.value();
         this.scope = scope;
-        this.clientIdProperty = clientIdProperty;
-        this.clientId = clientId;
-        this.clientSecretProperty = clientSecretProperty;
-        this.clientSecret = clientSecret;
-        this.usernameProperty = usernameProperty;
-        this.username = username;
-        this.passwordProperty = passwordProperty;
-        this.password = password;
+
+        this.clientIdProperty = clientId.property();
+        this.clientId = clientId.value();
+
+        this.clientSecretProperty = clientSecret.property();
+        this.clientSecret = clientSecret.value();
+
+        this.usernameProperty = username.property();
+        this.username = username.value();
+
+        this.passwordProperty = password.property();
+        this.password = password.value();
     }
 
     public String toBodyString() {
@@ -200,11 +201,13 @@ public class BasicAuthAccessTokenRequestForm {
             }
 
             return new BasicAuthAccessTokenRequestForm(
-                                                       grantTypeProperty, grantType, scope,
-                                                       clientIdProperty, clientId,
-                                                       clientSecretProperty, clientSecret,
-                                                       usernameProperty, username,
-                                                       passwordProperty, password);
+                                                       new PropertyValue(grantTypeProperty, grantType),
+                                                       scope,
+                                                       new PropertyValue(clientIdProperty, clientId),
+                                                       new PropertyValue(clientSecretProperty, clientSecret),
+                                                       new PropertyValue(usernameProperty, username),
+                                                       new PropertyValue(passwordProperty, password)
+                                                       );
         }
 
     }

--- a/src/main/java/io/aiven/kafka/connect/http/sender/request/PropertyValue.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/request/PropertyValue.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 Aiven Oy and http-connector-for-apache-kafka project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.http.sender.request;
+
+import java.util.Objects;
+
+final class PropertyValue {
+
+    private final String property;
+    private final String value;
+
+    PropertyValue(final String property, final String value) {
+        this.property = Objects.requireNonNull(property, "property must not be null");
+        this.value = Objects.requireNonNull(value, "value must not be null");
+    }
+
+    String property() {
+        return property;
+    }
+
+    String value() {
+        return value;
+    }
+}

--- a/src/test/java/io/aiven/kafka/connect/http/config/HttpSinkConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/config/HttpSinkConfigTest.java
@@ -281,7 +281,7 @@ final class HttpSinkConfigTest {
                 .describedAs("Expected config exception due to unsupported authorization type")
                 .isThrownBy(() -> new HttpSinkConfig(properties))
                 .withMessage("Invalid value unsupported for configuration http.authorization.type: "
-                        + "supported values are: [none, oauth2, static]");
+                        + "supported values are: [none, basic, oauth2, static]");
     }
 
     @Test

--- a/src/test/java/io/aiven/kafka/connect/http/sender/DefaultHttpSenderTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/sender/DefaultHttpSenderTest.java
@@ -181,7 +181,7 @@ public class DefaultHttpSenderTest extends HttpSenderTestBase {
                 messages.forEach(httpSender::send);
 
             })
-            .withMessage("Sending failed and no retries remain, stopping");
+            .withMessageContaining("status code 500");
     }
 
     private Map<String, String> defaultConfig() {

--- a/src/test/java/io/aiven/kafka/connect/http/sender/OAuth2AccessTokenHttpSenderTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/sender/OAuth2AccessTokenHttpSenderTest.java
@@ -242,7 +242,7 @@ public class OAuth2AccessTokenHttpSenderTest extends HttpSenderTestBase {
                 messages.forEach(httpSender::send);
 
             })
-            .withMessage("Sending failed and no retries remain, stopping");
+            .withMessageContaining("status code 500");
     }
 
     private Map<String, String> defaultConfig() {

--- a/src/test/java/io/aiven/kafka/connect/http/sender/OAuth2HttpSenderTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/sender/OAuth2HttpSenderTest.java
@@ -344,7 +344,8 @@ class OAuth2HttpSenderTest extends HttpSenderTestBase {
                 messages.forEach(httpSender::send);
 
             })
-            .withMessage("Sending failed and no retries remain, stopping");
+            .withMessageContaining("status code 401");
+                                                                              
 
         // Only 2 calls were made with 1 retry
         verify(oauth2AccessTokenHttpSender, times(2)).call();
@@ -417,7 +418,7 @@ class OAuth2HttpSenderTest extends HttpSenderTestBase {
                 messages.forEach(httpSender::send);
 
             })
-            .withMessage("Sending failed and no retries remain, stopping");
+            .withMessageContaining("status code 500");
     }
 
     private Map<String, String> defaultConfig() {

--- a/src/test/java/io/aiven/kafka/connect/http/sender/StaticAuthHttpSenderTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/sender/StaticAuthHttpSenderTest.java
@@ -188,7 +188,7 @@ public class StaticAuthHttpSenderTest extends HttpSenderTestBase {
                 messages.forEach(httpSender::send);
 
             })
-            .withMessage("Sending failed and no retries remain, stopping");
+            .withMessageContaining("status code 500");
     }
 
     private Map<String, String> defaultConfig() {


### PR DESCRIPTION
This authorization type `basic` for http connector enables the following configuration:
 
  ```
  
    "http.url": "GRAPHQL_ENDPOINT_API",
    "http.headers.content.type": "application/json",
    "http.authorization.type": "basic",

    "basic.access.token.url": "https://KEYCLOACK/auth/realms/onesaitplatform/protocol/openid-connect/token",
    "basic.client.id": "CLIENT_ID",
    "basic.client.secret": "SECRET",
    "basic.username": "USER",
    "basic.password": "PWD",
```

- [x] This branch should be merged into version0.9.0 or upper: this should be version0.9.0_basic
- [x] Keep debug logs in debug level
- [x] Extend doc with new options