### PR TITLE
renew token when basic and graphql: 200 with errors about token expired

### DIFF
--- a/src/main/java/io/aiven/kafka/connect/http/sender/AbstractHttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/AbstractHttpSender.java
@@ -76,13 +76,15 @@ abstract class AbstractHttpSender {
                     httpResponseHandler.onResponse(response, remainingRetries, config);
                     return response;
                 } catch (final IOException e) {
-                    log.debug("Sending failed, will retry in {} ms ({} retries remain) by {}",
-                             config.retryBackoffMs(),
-                             remainingRetries,
-                             e);
                     remainingRetries -= 1;
-                    TimeUnit.MILLISECONDS.sleep(config.retryBackoffMs());
                     msgError = e.toString();
+                    if (remainingRetries >= 0) {
+                        log.debug("Sending failed, will retry in {} ms ({} retries remain) {}",
+                                  config.retryBackoffMs(),
+                                  remainingRetries,
+                                  e);
+                        TimeUnit.MILLISECONDS.sleep(config.retryBackoffMs());
+                    }
                 }
             } catch (final InterruptedException e) {
                 log.error("Sending failed due to InterruptedException, stopping", e);

--- a/src/main/java/io/aiven/kafka/connect/http/sender/BasicAuthHttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/BasicAuthHttpSender.java
@@ -22,6 +22,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.Builder;
 import java.net.http.HttpResponse;
 import java.util.Map;
+import java.util.Locale;
 
 import org.apache.kafka.connect.errors.ConnectException;
 
@@ -30,6 +31,7 @@ import io.aiven.kafka.connect.http.sender.DefaultHttpSender.DefaultHttpRequestBu
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,6 +39,7 @@ import org.slf4j.LoggerFactory;
 class BasicAuthHttpSender extends AbstractHttpSender implements HttpSender {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BasicAuthHttpSender.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     BasicAuthHttpSender(
         final HttpSinkConfig config,
@@ -46,27 +49,60 @@ class BasicAuthHttpSender extends AbstractHttpSender implements HttpSender {
         super(config, new BasicAuthHttpRequestBuilder(config, basicAuthAccessTokenHttpSender), client);
     }
 
+    private boolean isGraphQlExpiredTokenResponse(final HttpResponse<String> response) {
+        if (response.statusCode() != 200 || !config.graphqlErrorsAsHttpError()) {
+            return false;
+        }
+        final String body = response.body();
+        if (body == null || body.isBlank()) {
+            return false;
+        }
+        try {
+            final JsonNode root = OBJECT_MAPPER.readTree(body);
+            final JsonNode errors = root.get("errors");
+            if (errors == null || !errors.isArray()) {
+                return false;
+            }
+            for (final JsonNode error : errors) {
+                final String message = error.has("message") ? error.get("message").asText("") : "";
+                final String normalized = message.toLowerCase(Locale.ROOT);
+                if (normalized.contains("401")
+                    && (normalized.contains("token expired")
+                        || normalized.contains("expired token")
+                        || normalized.contains("jwt expired")
+                        || normalized.contains("access token expired"))) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (final IOException e) {
+            return false;
+        }
+    }
+
     @Override
     protected HttpResponse<String> sendWithRetries(
-        final Builder requestBuilder,
-        final HttpResponseHandler originHandler,
+        final HttpRequest.Builder requestBuilderWithPayload,
+        final HttpResponseHandler originHttpResponseHandler,
         final int retries
     ) {
         final HttpResponseHandler composedHandler = (response, remainingRetries, config) -> {
             final int status = response.statusCode();
-            LOGGER.info("Server replied with status code {} and body {}",
-                       status, response.body());
 
-            // If we got Unauthorized (or Forbidden) and we still have retries left,
-            // renew the access token and force AbstractHttpSender to retry by throwing IOException.
-            if ((status == 401 || status == 403) && remainingRetries > 0) {
-                ((BasicAuthHttpRequestBuilder) this.httpRequestBuilder).renewAccessToken(requestBuilder);
-                throw new IOException(status + " received: renewed access token, retrying");
+            if (remainingRetries > 0) {
+                final boolean expiredToken =
+                    status == 401
+                    || status == 403
+                    || isGraphQlExpiredTokenResponse(response);
+
+                if (expiredToken) {
+                    ((BasicAuthHttpRequestBuilder) this.httpRequestBuilder).renewAccessToken(requestBuilderWithPayload);
+                    throw new IOException("Expired access token detected, renewed token and retrying");
+                }
             }
-            // Keep existing logic (GraphQL 200 with errors[], >=400, etc.)
-            originHandler.onResponse(response, remainingRetries, config);
+            originHttpResponseHandler.onResponse(response, remainingRetries, config);
         };
-        return super.sendWithRetries(requestBuilder, composedHandler, retries);
+        return super.sendWithRetries(requestBuilderWithPayload, composedHandler, retries);
     }
 
     private static class BasicAuthHttpRequestBuilder extends DefaultHttpRequestBuilder {
@@ -145,19 +181,18 @@ class BasicAuthHttpSender extends AbstractHttpSender implements HttpSender {
 
         private String buildAccessTokenAuthHeader(final String basicAuthResponseBody) throws JsonProcessingException {
             final var accessTokenResponse =
-                OBJECT_MAPPER.readValue(basicAuthResponseBody, new TypeReference<Map<String, String>>() {});
+                OBJECT_MAPPER.readValue(basicAuthResponseBody, new TypeReference<Map<String, Object>>() {});
             if (!accessTokenResponse.containsKey(ACCESS_TOKEN_FIELD)) {
                 throw new ConnectException("Couldn't find access token property "
                                            + ACCESS_TOKEN_FIELD
                                            + " in response properties: " + accessTokenResponse.keySet());
             }
-            final var tokenType = accessTokenResponse.getOrDefault("token_type", "Bearer");
-            final var accessToken = accessTokenResponse.get(ACCESS_TOKEN_FIELD);
+            final String tokenType = String.valueOf(accessTokenResponse.getOrDefault("token_type", "Bearer"));
+            final String accessToken = String.valueOf(accessTokenResponse.get(ACCESS_TOKEN_FIELD));
+            if (accessToken == null || accessToken.isBlank() || "null".equals(accessToken)) {
+                throw new ConnectException("Access token field '" + ACCESS_TOKEN_FIELD + "' is missing or blank");
+            }
             return String.format("%s %s", tokenType, accessToken);
         }
-
-        
-        
     }
-
 }

--- a/src/main/java/io/aiven/kafka/connect/http/sender/BasicAuthHttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/BasicAuthHttpSender.java
@@ -50,34 +50,9 @@ class BasicAuthHttpSender extends AbstractHttpSender implements HttpSender {
     }
 
     private boolean isGraphQlExpiredTokenResponse(final HttpResponse<String> response) {
-        if (response.statusCode() != 200 || !config.graphqlErrorsAsHttpError()) {
-            return false;
-        }
-        final String body = response.body();
-        if (body == null || body.isBlank()) {
-            return false;
-        }
-        try {
-            final JsonNode root = OBJECT_MAPPER.readTree(body);
-            final JsonNode errors = root.get("errors");
-            if (errors == null || !errors.isArray()) {
-                return false;
-            }
-            for (final JsonNode error : errors) {
-                final String message = error.has("message") ? error.get("message").asText("") : "";
-                final String normalized = message.toLowerCase(Locale.ROOT);
-                if (normalized.contains("401")
-                    && (normalized.contains("token expired")
-                        || normalized.contains("expired token")
-                        || normalized.contains("jwt expired")
-                        || normalized.contains("access token expired"))) {
-                    return true;
-                }
-            }
-            return false;
-        } catch (final IOException e) {
-            return false;
-        }
+        return response.statusCode() == 200
+            && config.graphqlErrorsAsHttpError()
+            && GraphQlErrorUtils.isExpiredToken(response.body());
     }
 
     @Override

--- a/src/main/java/io/aiven/kafka/connect/http/sender/GraphQLErrorUtils.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/GraphQLErrorUtils.java
@@ -1,0 +1,67 @@
+package io.aiven.kafka.connect.http.sender;
+
+import java.io.IOException;
+import java.util.Locale;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Utility class to inspect GraphQL responses and detect specific error conditions.
+ */
+final class GraphQlErrorUtils {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private GraphQlErrorUtils() {
+        // Utility class
+    }
+
+    /**
+     * Detects whether a GraphQL response body contains an expired access token error.
+     *
+     * Expected patterns (case-insensitive), typically inside errors[].message:
+     * - "401: Token expired"
+     * - "jwt expired"
+     * - "access token expired"
+     *
+     * @param body GraphQL response body
+     * @return true if an expired token is detected, false otherwise
+     */
+    static boolean isExpiredToken(final String body) {
+        if (body == null || body.isBlank()) {
+            return false;
+        }
+
+        try {
+            final JsonNode root = MAPPER.readTree(body);
+            final JsonNode errors = root.get("errors");
+
+            if (errors == null || !errors.isArray()) {
+                return false;
+            }
+
+            for (final JsonNode error : errors) {
+                final String message = error.has("message")
+                    ? error.get("message").asText("")
+                    : "";
+
+                final String normalized = message.toLowerCase(Locale.ROOT);
+
+                if (normalized.contains("401")
+                    && (normalized.contains("token expired")
+                        || normalized.contains("expired token")
+                        || normalized.contains("jwt expired")
+                        || normalized.contains("access token expired"))) {
+                    return true;
+                }
+            }
+
+            return false;
+
+        } catch (IOException e) {
+            // If parsing fails, we assume it's not a GraphQL error response
+            return false;
+        }
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/http/sender/GraphQLErrorUtils.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/GraphQLErrorUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Aiven Oy and http-connector-for-apache-kafka project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.aiven.kafka.connect.http.sender;
 
 import java.io.IOException;

--- a/src/test/java/io/aiven/kafka/connect/http/config/HttpSinkConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/config/HttpSinkConfigTest.java
@@ -210,6 +210,151 @@ final class HttpSinkConfigTest {
     }
 
     @Test
+    void invalidBasicAccessTokenUrl() {
+        final var emptyAccessTokenUrlConfig = Map.of(
+                "http.url", "http://localhost:8090",
+                "http.authorization.type", "basic",
+                "basic.access.token.url", "",
+                "basic.client.id", "client_id",
+                "basic.client.secret", "client_secret",
+                "basic.username", "user",
+                "basic.password", "password"
+        );
+
+        assertThatExceptionOfType(ConfigException.class)
+                .describedAs("Expected config exception due to empty Basic access token URL")
+                .isThrownBy(() -> new HttpSinkConfig(emptyAccessTokenUrlConfig))
+                .withMessage("Invalid value  for configuration basic.access.token.url: malformed URL");
+
+        final var wrongAccessTokenUrlConfig = Map.of(
+                "http.url", "http://localhost:8090",
+                "http.authorization.type", "basic",
+                "basic.access.token.url", ";http://localhost:8090",
+                "basic.client.id", "client_id",
+                "basic.client.secret", "client_secret",
+                "basic.username", "user",
+                "basic.password", "password"
+        );
+
+        assertThatExceptionOfType(ConfigException.class)
+                .describedAs("Expected config exception due to malformed Basic access token URL")
+                .isThrownBy(() -> new HttpSinkConfig(wrongAccessTokenUrlConfig))
+                .withMessage("Invalid value ;http://localhost:8090 for configuration basic.access.token.url: malformed URL");
+    }
+
+    @Test
+    void invalidBasicConfiguration() {
+        final var noAccessTokenUrlConfig = Map.of(
+                "http.url", "http://localhost:8090",
+                "http.authorization.type", "basic"
+        );
+
+        assertThatExceptionOfType(ConfigException.class)
+                .describedAs("Expected config exception due to missing Basic access token URL")
+                .isThrownBy(() -> new HttpSinkConfig(noAccessTokenUrlConfig))
+                .withMessageContaining("Must be present when http");
+        // .withMessage("Invalid value null for configuration basic.access.token.url: "
+        //                 + "Must be present when http.authorization.type = BASIC");
+
+        final var noClientIdConfig = Map.of(
+                "http.url", "http://localhost:8090",
+                "http.authorization.type", "basic",
+                "basic.access.token.url", "http://localhost:8090/token"
+        );
+
+        assertThatExceptionOfType(ConfigException.class)
+                .describedAs("Expected config exception due to missing Basic client id")
+                .isThrownBy(() -> new HttpSinkConfig(noClientIdConfig))
+                .withMessageContaining("Must be present when http");
+                // .withMessage("Invalid value null for configuration basic.client.id: "
+                //         + "Must be present when http.authorization.type = BASIC");
+
+        final var noSecretConfig = Map.of(
+                "http.url", "http://localhost:8090",
+                "http.authorization.type", "basic",
+                "basic.access.token.url", "http://localhost:8090/token",
+                "basic.client.id", "client_id"
+        );
+
+        assertThatExceptionOfType(ConfigException.class)
+                .describedAs("Expected config exception due to missing Basic client secret")
+                .isThrownBy(() -> new HttpSinkConfig(noSecretConfig))
+                .withMessageContaining("Must be present");
+                // .withMessage("Invalid value null for configuration basic.client.secret: "
+                //         + "Must be present when http.authorization.type = BASIC");
+
+        final var noUsernameConfig = Map.of(
+                "http.url", "http://localhost:8090",
+                "http.authorization.type", "basic",
+                "basic.access.token.url", "http://localhost:8090/token",
+                "basic.client.id", "client_id",
+                "basic.client.secret", "client_secret"
+        );
+
+        assertThatExceptionOfType(ConfigException.class)
+                .describedAs("Expected config exception due to missing Basic username")
+                .isThrownBy(() -> new HttpSinkConfig(noUsernameConfig))
+                .withMessageContaining("Must be present when http");
+
+        final var noPasswordConfig = Map.of(
+                "http.url", "http://localhost:8090",
+                "http.authorization.type", "basic",
+                "basic.access.token.url", "http://localhost:8090/token",
+                "basic.client.id", "client_id",
+                "basic.client.secret", "client_secret",
+                "basic.username", "user"
+        );
+
+        assertThatExceptionOfType(ConfigException.class)
+                .describedAs("Expected config exception due to missing Basic password")
+                .isThrownBy(() -> new HttpSinkConfig(noPasswordConfig))
+                .withMessageContaining("Must be present when http");
+    }
+
+    @Test
+    void validBasicMinimalConfiguration() throws URISyntaxException {
+        final var basicConfig = Map.of(
+                "http.url", "http://localhost:8090",
+                "http.authorization.type", "basic",
+                "basic.access.token.url", "http://localhost:8090/token",
+                "basic.client.id", "client_id",
+                "basic.client.secret", "client_secret",
+                "basic.username", "user",
+                "basic.password", "password"
+        );
+
+        final var config = new HttpSinkConfig(basicConfig);
+
+        assertThat(config)
+                .returns(AuthorizationType.BASIC, from(HttpSinkConfig::authorizationType))
+                .returns(new URI("http://localhost:8090/token"), from(HttpSinkConfig::basicAuthAccessTokenUri))
+                .returns("client_id", from(HttpSinkConfig::basicAuthClientId))
+                .returns("client_secret", from(httpSinkConfig -> httpSinkConfig.basicAuthClientSecret().value()))
+                .returns("user", from(HttpSinkConfig::basicAuthUsername))
+                .returns("password", from(httpSinkConfig -> httpSinkConfig.basicAuthPassword().value()))
+                .returns(null, from(HttpSinkConfig::basicAuthClientScope));
+    }
+
+    @Test
+    void validBasicGraphQlConfiguration() {
+        final var basicConfig = Map.of(
+                "http.url", "http://localhost:8090",
+                "http.authorization.type", "basic",
+                "basic.access.token.url", "http://localhost:8090/token",
+                "basic.client.id", "client_id",
+                "basic.client.secret", "client_secret",
+                "basic.username", "user",
+                "basic.password", "password",
+                "http.graphql.errors.as.http_error", "true"
+        );
+
+        final var config = new HttpSinkConfig(basicConfig);
+
+        assertThat(config.authorizationType()).isEqualTo(AuthorizationType.BASIC);
+        assertThat(config.graphqlErrorsAsHttpError()).isTrue();
+    }
+
+    @Test
     void invalidUrl() {
         final Map<String, String> properties = Map.of(
                 "http.url", "#http://localhost:8090",
@@ -258,6 +403,16 @@ final class HttpSinkConfigTest {
                                 "http.url", "http://localhost:8090",
                                 "http.authorization.type", AuthorizationType.STATIC.name,
                                 "http.headers.authorization", "some"
+                        )),
+                Arguments.of(AuthorizationType.BASIC,
+                        Map.of(
+                                "http.url", "http://localhost:8090",
+                                "http.authorization.type", AuthorizationType.BASIC.name,
+                                "basic.access.token.url", "http://localhost:42/token",
+                                "basic.client.id", "client_id",
+                                "basic.client.secret", "client_secret",
+                                "basic.username", "user",
+                                "basic.password", "password"
                         )),
                 Arguments.of(AuthorizationType.OAUTH2,
                         Map.of(

--- a/src/test/java/io/aiven/kafka/connect/http/sender/BasicAcessTokenHttpSenderTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/sender/BasicAcessTokenHttpSenderTest.java
@@ -1,0 +1,176 @@
+package io.aiven.kafka.connect.http.sender;
+
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.Builder;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandler;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.errors.ConnectException;
+
+import io.aiven.kafka.connect.http.config.HttpSinkConfig;
+
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BasicAuthAccessTokenHttpSenderTest extends HttpSenderTestBase {
+
+    @Test
+    void shouldThrowExceptionWithoutConfig() {
+        assertThrows(NullPointerException.class, () -> new BasicAuthAccessTokenHttpSender(null, null));
+    }
+
+    @Test
+    void shouldBuildDefaultAccessTokenRequest() throws Exception {
+        final HttpSinkConfig config = new HttpSinkConfig(defaultConfig());
+
+        when(mockedClient.send(any(HttpRequest.class), any(BodyHandler.class))).thenReturn(mockedResponse);
+
+        final var httpSender = Mockito.spy(new BasicAuthAccessTokenHttpSender(config, mockedClient));
+
+        final List<String> messages = List.of(
+            "grant_type=password"
+                + "&client_id=some_client_id"
+                + "&client_secret=some_client_secret"
+                + "&username=some_user"
+                + "&password=some_password"
+        );
+        httpSender.call();
+
+        final ArgumentCaptor<Builder> defaultHttpRequestBuilder = ArgumentCaptor.forClass(HttpRequest.Builder.class);
+        verify(httpSender, atLeast(messages.size())).sendWithRetries(
+            defaultHttpRequestBuilder.capture(),
+            any(HttpResponseHandler.class),
+            anyInt()
+        );
+
+        defaultHttpRequestBuilder
+            .getAllValues()
+            .stream()
+            .map(Builder::build)
+            .forEach(httpRequest -> {
+                assertThat(httpRequest.uri()).isEqualTo(config.basicAuthAccessTokenUri());
+                assertThat(httpRequest.timeout())
+                    .isPresent()
+                    .get(as(InstanceOfAssertFactories.DURATION))
+                    .hasSeconds(config.httpTimeout());
+                assertThat(httpRequest.method()).isEqualTo("POST");
+
+                assertThat(httpRequest.headers()
+                    .firstValue(HttpRequestBuilder.HEADER_CONTENT_TYPE))
+                    .hasValue("application/x-www-form-urlencoded");
+
+                assertThat(httpRequest.headers()
+                    .firstValue(HttpRequestBuilder.HEADER_AUTHORIZATION))
+                    .isEmpty();
+            });
+
+        messages.forEach(
+            message -> bodyPublishers.verify(() -> HttpRequest.BodyPublishers.ofString(eq(message)))
+        );
+    }
+
+    @Test
+    void shouldBuildAccessTokenRequestWithScope() throws Exception {
+        final Map<String, String> configBase = new HashMap<>(defaultConfig());
+        configBase.put("basic.client.scope", "scope1,scope2");
+
+        final HttpSinkConfig config = new HttpSinkConfig(configBase);
+
+        when(mockedClient.send(any(HttpRequest.class), any(BodyHandler.class))).thenReturn(mockedResponse);
+
+        final var httpSender = Mockito.spy(new BasicAuthAccessTokenHttpSender(config, mockedClient));
+
+        final List<String> messages = List.of(
+            "grant_type=password"
+                + "&scope=scope1%2Cscope2"
+                + "&client_id=some_client_id"
+                + "&client_secret=some_client_secret"
+                + "&username=some_user"
+                + "&password=some_password"
+        );
+        httpSender.call();
+
+        final ArgumentCaptor<Builder> defaultHttpRequestBuilder = ArgumentCaptor.forClass(HttpRequest.Builder.class);
+        verify(httpSender, atLeast(messages.size())).sendWithRetries(
+            defaultHttpRequestBuilder.capture(),
+            any(HttpResponseHandler.class),
+            anyInt()
+        );
+
+        defaultHttpRequestBuilder
+            .getAllValues()
+            .stream()
+            .map(Builder::build)
+            .forEach(httpRequest -> {
+                assertThat(httpRequest.uri()).isEqualTo(config.basicAuthAccessTokenUri());
+                assertThat(httpRequest.timeout())
+                    .isPresent()
+                    .get(as(InstanceOfAssertFactories.DURATION))
+                    .hasSeconds(config.httpTimeout());
+                assertThat(httpRequest.method()).isEqualTo("POST");
+
+                assertThat(httpRequest.headers()
+                    .firstValue(HttpRequestBuilder.HEADER_CONTENT_TYPE))
+                    .hasValue("application/x-www-form-urlencoded");
+
+                assertThat(httpRequest.headers()
+                    .firstValue(HttpRequestBuilder.HEADER_AUTHORIZATION))
+                    .isEmpty();
+            });
+
+        messages.forEach(
+            message -> bodyPublishers.verify(() -> HttpRequest.BodyPublishers.ofString(eq(message)))
+        );
+    }
+
+    @Test
+    void throwsConnectExceptionForServerError() {
+        final HttpResponse<String> errorResponse = mock(HttpResponse.class);
+        when(errorResponse.statusCode()).thenReturn(500);
+
+        assertThatExceptionOfType(ConnectException.class)
+            .isThrownBy(() -> {
+                final HttpSinkConfig config = new HttpSinkConfig(defaultConfig());
+
+                when(mockedClient.send(any(HttpRequest.class), any(BodyHandler.class))).thenReturn(errorResponse);
+
+                final var httpSender = Mockito.spy(new BasicAuthAccessTokenHttpSender(config, mockedClient));
+
+                final List<String> messages = List.of("some message 1", "some message 2");
+                messages.forEach(httpSender::send);
+            })
+            .withMessageContaining("status code 500");
+    }
+
+    private Map<String, String> defaultConfig() {
+        return Map.of(
+            "http.url", "http://localhost:42",
+            "http.authorization.type", "basic",
+            "basic.access.token.url", "http://localhost:42/token",
+            "basic.client.id", "some_client_id",
+            "basic.client.secret", "some_client_secret",
+            "basic.username", "some_user",
+            "basic.password", "some_password"
+        );
+    }
+}

--- a/src/test/java/io/aiven/kafka/connect/http/sender/BasicAcessTokenHttpSenderTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/sender/BasicAcessTokenHttpSenderTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Aiven Oy and http-connector-for-apache-kafka project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.aiven.kafka.connect.http.sender;
 
 import java.net.http.HttpRequest;

--- a/src/test/java/io/aiven/kafka/connect/http/sender/BasicAuthHttpSenderTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/sender/BasicAuthHttpSenderTest.java
@@ -362,6 +362,132 @@ class BasicAuthHttpSenderTest extends HttpSenderTestBase {
             .withMessageContaining("status code 500");
     }
 
+    @Test
+    void doesNotRefreshAccessTokenOnGraphQlInternalServerError() throws Exception {
+        final HttpResponse<String> mockedAccessTokenResponse = mock(HttpResponse.class);
+        when(mockedAccessTokenResponse.body()).thenReturn(ACCESS_TOKEN_RESPONSE);
+        when(basicAuthAccessTokenHttpSender.call()).thenReturn(mockedAccessTokenResponse);
+
+        final HttpResponse<String> graphQlErrorResponse = mock(HttpResponse.class);
+        when(graphQlErrorResponse.statusCode()).thenReturn(200);
+        when(graphQlErrorResponse.body()).thenReturn(
+                                                     "{\"data\":{\"updateAdvice\":null},"
+                                                     + "\"errors\":[{\"message\":\"Redis Cluster cannot be connected. "
+                                                     + "Please provide at least one reachable node: None\","
+                                                     + "\"locations\":[{\"line\":3,\"column\":17}],"
+                                                     + "\"path\":[\"updateAdvice\"]}]}"
+                                                     );
+
+        final HttpSinkConfig config = new HttpSinkConfig(defaultGraphQlConfig());
+
+        when(mockedClient.send(any(HttpRequest.class), any(BodyHandler.class))).thenReturn(graphQlErrorResponse);
+
+        assertThatExceptionOfType(ConnectException.class)
+            .isThrownBy(() -> {
+                    final var httpSender =
+                        Mockito.spy(new BasicAuthHttpSender(config, mockedClient, basicAuthAccessTokenHttpSender));
+                    httpSender.send("some message");
+                })
+            .withMessageContaining("status code 200")
+            .withMessageContaining("body with errors");
+
+        // Token requested only once: initial token retrieval, no refresh
+        verify(basicAuthAccessTokenHttpSender, times(1)).call();
+
+        // With default max.retries=1, one initial attempt + one retry
+        verify(mockedClient, times(2)).send(any(HttpRequest.class), any(BodyHandler.class));
+    }
+
+    @Test
+    void doesNotRefreshAccessTokenOnGraphQl401LikeErrorThatIsNotTokenExpired() throws Exception {
+        final HttpResponse<String> mockedAccessTokenResponse = mock(HttpResponse.class);
+        when(mockedAccessTokenResponse.body()).thenReturn(ACCESS_TOKEN_RESPONSE);
+        when(basicAuthAccessTokenHttpSender.call()).thenReturn(mockedAccessTokenResponse);
+
+        final HttpResponse<String> graphQlErrorResponse = mock(HttpResponse.class);
+        when(graphQlErrorResponse.statusCode()).thenReturn(200);
+        when(graphQlErrorResponse.body()).thenReturn(
+                                                     "{\"data\":{\"updateAdvice\":null},"
+                                                     + "\"errors\":[{\"message\":\"401: unauthorized operation for this resource\","
+                                                     + "\"locations\":[{\"line\":3,\"column\":17}],"
+                                                     + "\"path\":[\"updateAdvice\"]}]}"
+                                                     );
+
+        final HttpSinkConfig config = new HttpSinkConfig(defaultGraphQlConfig());
+
+        when(mockedClient.send(any(HttpRequest.class), any(BodyHandler.class))).thenReturn(graphQlErrorResponse);
+
+        assertThatExceptionOfType(ConnectException.class)
+            .isThrownBy(() -> {
+                    final var httpSender =
+                        Mockito.spy(new BasicAuthHttpSender(config, mockedClient, basicAuthAccessTokenHttpSender));
+                    httpSender.send("some message");
+                })
+            .withMessageContaining("status code 200")
+            .withMessageContaining("body with errors");
+
+        // Token requested only once: initial token retrieval, no refresh
+        verify(basicAuthAccessTokenHttpSender, times(1)).call();
+
+        // With default max.retries=1, one initial attempt + one retry
+        verify(mockedClient, times(2)).send(any(HttpRequest.class), any(BodyHandler.class));
+    }
+
+    @Test
+    void refreshAccessTokenOnGraphQlExpiredTokenResponseCaseInsensitive() throws Exception {
+        final HttpResponse<String> mockedAccessTokenResponse = mock(HttpResponse.class);
+        when(mockedAccessTokenResponse.body()).thenReturn(ACCESS_TOKEN_RESPONSE);
+
+        final HttpResponse<String> mockedAccessTokenResponseRefreshed = mock(HttpResponse.class);
+        when(mockedAccessTokenResponseRefreshed.body()).thenReturn(
+                                                                   "{\"access_token\": \"my_refreshed_token\",\"token_type\": \"Bearer\",\"expires_in\": 7199}");
+
+        when(basicAuthAccessTokenHttpSender.call()).thenReturn(
+                                                               mockedAccessTokenResponse, mockedAccessTokenResponseRefreshed);
+
+        final HttpResponse<String> expiredTokenGraphQlResponse = mock(HttpResponse.class);
+        when(expiredTokenGraphQlResponse.statusCode()).thenReturn(200);
+        when(expiredTokenGraphQlResponse.body()).thenReturn(
+                                                            "{\"data\":{\"updateLocation\":null},"
+                                                            + "\"errors\":[{\"message\":\"401: TOKEN EXPIRED\","
+                                                            + "\"locations\":[{\"line\":3,\"column\":17}],"
+                                                            + "\"path\":[\"updateLocation\"]}]}"
+                                                            );
+
+        final HttpResponse<String> normalResponse = mock(HttpResponse.class);
+        when(normalResponse.statusCode()).thenReturn(200);
+        when(normalResponse.body()).thenReturn("{\"data\":{\"updateLocation\":{\"id\":\"ok\"}}}");
+
+        final HttpSinkConfig config = new HttpSinkConfig(defaultGraphQlConfig());
+
+        when(mockedClient.send(any(HttpRequest.class), any(BodyHandler.class))).thenReturn(
+                                                                                           expiredTokenGraphQlResponse, normalResponse);
+
+        final var httpSender =
+            Mockito.spy(new BasicAuthHttpSender(config, mockedClient, basicAuthAccessTokenHttpSender));
+
+        httpSender.send("some message");
+
+        final ArgumentCaptor<HttpRequest> httpRequestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(mockedClient, times(2)).send(httpRequestCaptor.capture(), any(BodyHandler.class));
+
+        final List<HttpRequest> httpRequests = httpRequestCaptor.getAllValues();
+
+        assertThat(httpRequests).hasSize(2);
+
+        assertThat(httpRequests.get(0)
+                   .headers()
+                   .firstValue(HttpRequestBuilder.HEADER_AUTHORIZATION)
+                   .orElse(null)).isEqualTo("Bearer my_access_token");
+
+        assertThat(httpRequests.get(1)
+                   .headers()
+                   .firstValue(HttpRequestBuilder.HEADER_AUTHORIZATION)
+                   .orElse(null)).isEqualTo("Bearer my_refreshed_token");
+
+        verify(basicAuthAccessTokenHttpSender, times(2)).call();
+    }
+
     private Map<String, String> defaultConfig() {
         return Map.of(
             "http.url", "http://localhost:42",

--- a/src/test/java/io/aiven/kafka/connect/http/sender/BasicAuthHttpSenderTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/sender/BasicAuthHttpSenderTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Aiven Oy and http-connector-for-apache-kafka project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.aiven.kafka.connect.http.sender;
 
 import java.io.IOException;

--- a/src/test/java/io/aiven/kafka/connect/http/sender/BasicAuthHttpSenderTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/sender/BasicAuthHttpSenderTest.java
@@ -1,0 +1,389 @@
+package io.aiven.kafka.connect.http.sender;
+
+import java.io.IOException;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.Builder;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandler;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.apache.kafka.connect.errors.ConnectException;
+
+import io.aiven.kafka.connect.http.config.HttpSinkConfig;
+
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BasicAuthHttpSenderTest extends HttpSenderTestBase {
+
+    static final String ACCESS_TOKEN_RESPONSE =
+        "{\"access_token\": \"my_access_token\",\"token_type\": \"Bearer\",\"expires_in\": 7199}";
+
+    @Mock
+    private BasicAuthAccessTokenHttpSender basicAuthAccessTokenHttpSender;
+
+    @Test
+    void shouldThrowExceptionWithoutConfig() {
+        assertThrows(NullPointerException.class, () -> new BasicAuthHttpSender(null, null, null));
+    }
+
+    @Test
+    void shouldBuildDefaultHttpRequest() throws Exception {
+        final HttpResponse<String> mockedAccessTokenResponse = mock(HttpResponse.class);
+        when(mockedAccessTokenResponse.body()).thenReturn(ACCESS_TOKEN_RESPONSE);
+        when(basicAuthAccessTokenHttpSender.call()).thenReturn(mockedAccessTokenResponse);
+
+        final HttpSinkConfig config = new HttpSinkConfig(defaultConfig());
+
+        when(mockedClient.send(any(HttpRequest.class), any(BodyHandler.class))).thenReturn(mockedResponse);
+
+        final var httpSender = Mockito.spy(new BasicAuthHttpSender(config, mockedClient, basicAuthAccessTokenHttpSender));
+
+        final List<String> messages = List.of("some message");
+        messages.forEach(httpSender::send);
+
+        final ArgumentCaptor<Builder> defaultHttpRequestBuilder = ArgumentCaptor.forClass(HttpRequest.Builder.class);
+        verify(httpSender, atLeast(messages.size())).sendWithRetries(
+            defaultHttpRequestBuilder.capture(),
+            any(HttpResponseHandler.class),
+            anyInt()
+        );
+
+        defaultHttpRequestBuilder
+            .getAllValues()
+            .stream()
+            .map(Builder::build)
+            .forEach(httpRequest -> {
+                assertThat(httpRequest.uri()).isEqualTo(config.httpUri());
+                assertThat(httpRequest.timeout())
+                    .isPresent()
+                    .get(as(InstanceOfAssertFactories.DURATION))
+                    .hasSeconds(config.httpTimeout());
+                assertThat(httpRequest.method()).isEqualTo("POST");
+
+                assertThat(httpRequest
+                    .headers()
+                    .firstValue(HttpRequestBuilder.HEADER_AUTHORIZATION)
+                    .orElse(null)).isEqualTo("Bearer my_access_token");
+            });
+
+        messages.forEach(
+            message -> bodyPublishers.verify(() -> HttpRequest.BodyPublishers.ofString(eq(message)))
+        );
+        verify(mockedClient, times(messages.size())).send(any(HttpRequest.class), any(BodyHandler.class));
+    }
+
+    @Test
+    void reuseAccessToken() throws Exception {
+        final HttpResponse<String> mockedAccessTokenResponse = mock(HttpResponse.class);
+        when(mockedAccessTokenResponse.body()).thenReturn(ACCESS_TOKEN_RESPONSE);
+        when(basicAuthAccessTokenHttpSender.call()).thenReturn(mockedAccessTokenResponse);
+
+        final HttpSinkConfig config = new HttpSinkConfig(defaultConfig());
+
+        when(mockedClient.send(any(HttpRequest.class), any(BodyHandler.class))).thenReturn(mockedResponse);
+
+        final var httpSender = Mockito.spy(new BasicAuthHttpSender(config, mockedClient, basicAuthAccessTokenHttpSender));
+
+        final List<String> messages = List.of("some message 1", "some message 2");
+        messages.forEach(httpSender::send);
+
+        final ArgumentCaptor<Builder> defaultHttpRequestBuilder = ArgumentCaptor.forClass(HttpRequest.Builder.class);
+        verify(httpSender, atLeast(messages.size())).sendWithRetries(
+            defaultHttpRequestBuilder.capture(),
+            any(HttpResponseHandler.class),
+            anyInt()
+        );
+
+        defaultHttpRequestBuilder
+            .getAllValues()
+            .stream()
+            .map(Builder::build)
+            .forEach(httpRequest -> {
+                assertThat(httpRequest.uri()).isEqualTo(config.httpUri());
+                assertThat(httpRequest.timeout())
+                    .isPresent()
+                    .get(as(InstanceOfAssertFactories.DURATION))
+                    .hasSeconds(config.httpTimeout());
+                assertThat(httpRequest.method()).isEqualTo("POST");
+
+                assertThat(httpRequest
+                    .headers()
+                    .firstValue(HttpRequestBuilder.HEADER_AUTHORIZATION)
+                    .orElse(null)).isEqualTo("Bearer my_access_token");
+            });
+
+        verify(basicAuthAccessTokenHttpSender).call();
+
+        messages.forEach(
+            message -> bodyPublishers.verify(() -> HttpRequest.BodyPublishers.ofString(eq(message)))
+        );
+        verify(mockedClient, times(messages.size())).send(any(HttpRequest.class), any(BodyHandler.class));
+    }
+
+    @Test
+    void refreshAccessTokenOnUnauthorizedResponse() throws Exception {
+        final HttpResponse<String> mockedAccessTokenResponse = mock(HttpResponse.class);
+        when(mockedAccessTokenResponse.body()).thenReturn(ACCESS_TOKEN_RESPONSE);
+        
+        final HttpResponse<String> mockedAccessTokenResponseRefreshed = mock(HttpResponse.class);
+        when(mockedAccessTokenResponseRefreshed.body()).thenReturn(
+                                                                   "{\"access_token\": \"my_refreshed_token\",\"token_type\": \"Bearer\",\"expires_in\": 7199}");
+        when(basicAuthAccessTokenHttpSender.call()).thenReturn(
+                                                               mockedAccessTokenResponse, mockedAccessTokenResponseRefreshed);
+        
+        final HttpResponse<String> errorResponse = mock(HttpResponse.class);
+        when(errorResponse.statusCode()).thenReturn(401);
+        
+        final HttpResponse<String> normalResponse = mock(HttpResponse.class);
+        when(normalResponse.statusCode()).thenReturn(200);
+        when(normalResponse.body()).thenReturn("{\"data\":{\"ok\":true}}");
+        
+        final HttpSinkConfig config = new HttpSinkConfig(defaultConfig());
+        
+        when(mockedClient.send(any(HttpRequest.class), any(BodyHandler.class))).thenReturn(
+                                                                                           mockedResponse, errorResponse, normalResponse);
+        
+        final var httpSender = Mockito.spy(new BasicAuthHttpSender(config, mockedClient, basicAuthAccessTokenHttpSender));
+        
+        final List<String> messages = List.of("some message 1", "some message 2");
+        messages.forEach(httpSender::send);
+        
+        final ArgumentCaptor<HttpRequest> httpRequestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(mockedClient, times(messages.size() + 1)).send(httpRequestCaptor.capture(), any(BodyHandler.class));
+        
+        final List<HttpRequest> httpRequests = httpRequestCaptor.getAllValues();
+        
+        assertThat(httpRequests).hasSize(3);
+        
+        httpRequests.forEach(httpRequest -> {
+                assertThat(httpRequest.uri()).isEqualTo(config.httpUri());
+                assertThat(httpRequest.timeout())
+                    .isPresent()
+                    .get(as(InstanceOfAssertFactories.DURATION))
+                    .hasSeconds(config.httpTimeout());
+                assertThat(httpRequest.method()).isEqualTo("POST");
+            });
+        
+        assertThat(httpRequests.get(0)
+                   .headers()
+                   .firstValue(HttpRequestBuilder.HEADER_AUTHORIZATION)
+                   .orElse(null)).isEqualTo("Bearer my_access_token");
+
+        assertThat(httpRequests.get(1)
+                   .headers()
+                   .firstValue(HttpRequestBuilder.HEADER_AUTHORIZATION)
+                   .orElse(null)).isEqualTo("Bearer my_access_token");
+        
+        assertThat(httpRequests.get(2)
+                   .headers()
+                   .firstValue(HttpRequestBuilder.HEADER_AUTHORIZATION)
+                   .orElse(null)).isEqualTo("Bearer my_refreshed_token");
+
+        verify(basicAuthAccessTokenHttpSender, times(2)).call();
+        
+        messages.forEach(
+                         message -> bodyPublishers.verify(() -> HttpRequest.BodyPublishers.ofString(eq(message)))
+                         );
+        verify(mockedClient, times(messages.size() + 1)).send(any(HttpRequest.class), any(BodyHandler.class));
+    }
+
+    @Test
+    void refreshAccessTokenOnGraphQlExpiredTokenResponse() throws Exception {
+        final HttpResponse<String> mockedAccessTokenResponse = mock(HttpResponse.class);
+        when(mockedAccessTokenResponse.body()).thenReturn(ACCESS_TOKEN_RESPONSE);
+        
+        final HttpResponse<String> mockedAccessTokenResponseRefreshed = mock(HttpResponse.class);
+        when(mockedAccessTokenResponseRefreshed.body()).thenReturn(
+                                                                   "{\"access_token\": \"my_refreshed_token\",\"token_type\": \"Bearer\",\"expires_in\": 7199}");
+        when(basicAuthAccessTokenHttpSender.call()).thenReturn(
+                                                               mockedAccessTokenResponse, mockedAccessTokenResponseRefreshed);
+        
+        final HttpResponse<String> expiredTokenGraphQlResponse = mock(HttpResponse.class);
+        when(expiredTokenGraphQlResponse.statusCode()).thenReturn(200);
+        when(expiredTokenGraphQlResponse.body()).thenReturn(
+                                                            "{\"data\":{\"updateLocation\":null},"
+                                                            + "\"errors\":[{\"message\":\"401: Token expired\",\"locations\":[{\"line\":3,\"column\":17}],"
+                                                            + "\"path\":[\"updateLocation\"]}]}"
+                                                            );
+        
+        final HttpResponse<String> normalResponse = mock(HttpResponse.class);
+        when(normalResponse.statusCode()).thenReturn(200);
+        when(normalResponse.body()).thenReturn("{\"data\":{\"updateLocation\":{\"id\":\"ok\"}}}");
+        
+        final HttpSinkConfig config = new HttpSinkConfig(defaultGraphQlConfig());
+        
+        when(mockedClient.send(any(HttpRequest.class), any(BodyHandler.class))).thenReturn(
+                                                                                           expiredTokenGraphQlResponse, normalResponse);
+        
+        final var httpSender = Mockito.spy(new BasicAuthHttpSender(config, mockedClient, basicAuthAccessTokenHttpSender));
+        
+        httpSender.send("some message");
+        
+        final ArgumentCaptor<HttpRequest> httpRequestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(mockedClient, times(2)).send(httpRequestCaptor.capture(), any(BodyHandler.class));
+        
+        final List<HttpRequest> httpRequests = httpRequestCaptor.getAllValues();
+
+        assertThat(httpRequests).hasSize(2);
+        
+        httpRequests.forEach(httpRequest -> {
+                assertThat(httpRequest.uri()).isEqualTo(config.httpUri());
+                assertThat(httpRequest.timeout())
+                    .isPresent()
+                    .get(as(InstanceOfAssertFactories.DURATION))
+                    .hasSeconds(config.httpTimeout());
+                assertThat(httpRequest.method()).isEqualTo("POST");
+            });
+        
+        assertThat(httpRequests.get(0)
+                   .headers()
+                   .firstValue(HttpRequestBuilder.HEADER_AUTHORIZATION)
+                   .orElse(null)).isEqualTo("Bearer my_access_token");
+        
+        assertThat(httpRequests.get(1)
+                   .headers()
+                   .firstValue(HttpRequestBuilder.HEADER_AUTHORIZATION)
+                   .orElse(null)).isEqualTo("Bearer my_refreshed_token");
+        
+        verify(basicAuthAccessTokenHttpSender, times(2)).call();
+        verify(mockedClient, times(2)).send(any(HttpRequest.class), any(BodyHandler.class));
+    }
+
+    @Test
+    void throwsConnectExceptionForUnauthorizedToken() {
+        final HttpResponse<String> mockedAccessTokenResponse = mock(HttpResponse.class);
+        when(mockedAccessTokenResponse.body()).thenReturn(ACCESS_TOKEN_RESPONSE);
+        when(basicAuthAccessTokenHttpSender.call()).thenReturn(
+            mockedAccessTokenResponse, mockedAccessTokenResponse);
+
+        final HttpResponse<String> errorResponse = mock(HttpResponse.class);
+        when(errorResponse.statusCode()).thenReturn(401);
+
+        assertThatExceptionOfType(ConnectException.class)
+            .isThrownBy(() -> {
+                final HttpSinkConfig config = new HttpSinkConfig(defaultConfig());
+
+                when(mockedClient.send(any(HttpRequest.class), any(BodyHandler.class))).thenReturn(errorResponse);
+
+                final var httpSender =
+                    Mockito.spy(new BasicAuthHttpSender(config, mockedClient, basicAuthAccessTokenHttpSender));
+
+                final List<String> messages = List.of("some message 1", "some message 2");
+                messages.forEach(httpSender::send);
+            })
+            .withMessageContaining("status code 401");
+
+        verify(basicAuthAccessTokenHttpSender, times(2)).call();
+    }
+
+    @Test
+    void throwsConnectExceptionForWrongAuthentication() throws IOException, InterruptedException {
+        final HttpResponse<String> mockedAccessTokenResponse = mock(HttpResponse.class);
+        when(mockedAccessTokenResponse.body()).thenReturn("not a json");
+        when(basicAuthAccessTokenHttpSender.call()).thenReturn(mockedAccessTokenResponse);
+
+        assertThatExceptionOfType(ConnectException.class)
+            .isThrownBy(() -> new BasicAuthHttpSender(
+                new HttpSinkConfig(defaultConfig()),
+                mockedClient,
+                basicAuthAccessTokenHttpSender
+            ).send("a message"))
+            .withMessage("Couldn't get BasicAuth access token");
+
+        verify(basicAuthAccessTokenHttpSender).call();
+        verify(mockedClient, never()).send(any(HttpRequest.class), any(BodyHandler.class));
+    }
+
+    @Test
+    void throwsConnectExceptionForBadFormedAccessToken() throws IOException, InterruptedException {
+        final HttpResponse<String> mockedAccessTokenResponse = mock(HttpResponse.class);
+        when(mockedAccessTokenResponse.body()).thenReturn(
+            "{\"bad_property\": \"my_access_token\",\"token_type\": \"Bearer\",\"expires_in\": 7199}");
+        when(basicAuthAccessTokenHttpSender.call()).thenReturn(mockedAccessTokenResponse);
+
+        assertThatExceptionOfType(ConnectException.class)
+            .isThrownBy(() -> new BasicAuthHttpSender(
+                new HttpSinkConfig(defaultConfig()),
+                mockedClient,
+                basicAuthAccessTokenHttpSender
+            ).send("a message"))
+            .withMessage("Couldn't find access token property access_token in"
+                + " response properties: [bad_property, token_type, expires_in]");
+
+        verify(basicAuthAccessTokenHttpSender).call();
+        verify(mockedClient, never()).send(any(HttpRequest.class), any(BodyHandler.class));
+    }
+
+    @Test
+    void throwsConnectExceptionForServerError() {
+        final HttpResponse<String> mockedAccessTokenResponse = mock(HttpResponse.class);
+        when(mockedAccessTokenResponse.body()).thenReturn(ACCESS_TOKEN_RESPONSE);
+        when(basicAuthAccessTokenHttpSender.call()).thenReturn(mockedAccessTokenResponse);
+
+        final HttpResponse<String> errorResponse = mock(HttpResponse.class);
+        when(errorResponse.statusCode()).thenReturn(500);
+
+        assertThatExceptionOfType(ConnectException.class)
+            .isThrownBy(() -> {
+                final HttpSinkConfig config = new HttpSinkConfig(defaultConfig());
+
+                when(mockedClient.send(any(HttpRequest.class), any(BodyHandler.class))).thenReturn(errorResponse);
+
+                final var httpSender =
+                    Mockito.spy(new BasicAuthHttpSender(config, mockedClient, basicAuthAccessTokenHttpSender));
+
+                final List<String> messages = List.of("some message 1", "some message 2");
+                messages.forEach(httpSender::send);
+            })
+            .withMessageContaining("status code 500");
+    }
+
+    private Map<String, String> defaultConfig() {
+        return Map.of(
+            "http.url", "http://localhost:42",
+            "http.authorization.type", "basic",
+            "basic.access.token.url", "http://localhost:42/token",
+            "basic.client.id", "some_client_id",
+            "basic.client.secret", "some_client_secret",
+            "basic.username", "some_user",
+            "basic.password", "some_password"
+        );
+    }
+
+    private Map<String, String> defaultGraphQlConfig() {
+        return Map.of(
+            "http.url", "http://localhost:42",
+            "http.authorization.type", "basic",
+            "basic.access.token.url", "http://localhost:42/token",
+            "basic.client.id", "some_client_id",
+            "basic.client.secret", "some_client_secret",
+            "basic.username", "some_user",
+            "basic.password", "some_password",
+            "http.graphql.errors.as.http_error", "true"
+        );
+    }
+}

--- a/src/test/java/io/aiven/kafka/connect/http/sender/GraphQLErrorUtilTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/sender/GraphQLErrorUtilTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Aiven Oy and http-connector-for-apache-kafka project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.aiven.kafka.connect.http.sender;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/io/aiven/kafka/connect/http/sender/GraphQLErrorUtilTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/sender/GraphQLErrorUtilTest.java
@@ -1,0 +1,117 @@
+package io.aiven.kafka.connect.http.sender;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GraphQlErrorUtilsTest {
+
+    @Test
+    void detectsExpiredToken() {
+        final String body =
+            "{"
+                + "\"errors\": ["
+                + "{ \"message\": \"401: Token expired\" }"
+                + "]"
+                + "}";
+
+        assertThat(GraphQlErrorUtils.isExpiredToken(body)).isTrue();
+    }
+
+    @Test
+    void detectsExpiredTokenCaseInsensitive() {
+        final String body =
+            "{"
+                + "\"errors\": ["
+                + "{ \"message\": \"401: TOKEN EXPIRED\" }"
+                + "]"
+                + "}";
+
+        assertThat(GraphQlErrorUtils.isExpiredToken(body)).isTrue();
+    }
+
+    @Test
+    void detectsJwtExpired() {
+        final String body =
+            "{"
+                + "\"errors\": ["
+                + "{ \"message\": \"401: jwt expired\" }"
+                + "]"
+                + "}";
+
+        assertThat(GraphQlErrorUtils.isExpiredToken(body)).isTrue();
+    }
+
+    @Test
+    void detectsAccessTokenExpired() {
+        final String body =
+            "{"
+                + "\"errors\": ["
+                + "{ \"message\": \"401: access token expired\" }"
+                + "]"
+                + "}";
+
+        assertThat(GraphQlErrorUtils.isExpiredToken(body)).isTrue();
+    }
+
+    @Test
+    void doesNotDetectOtherErrors() {
+        final String body =
+            "{"
+                + "\"errors\": ["
+                + "{ \"message\": \"Redis cluster not reachable\" }"
+                + "]"
+                + "}";
+
+        assertThat(GraphQlErrorUtils.isExpiredToken(body)).isFalse();
+    }
+
+    @Test
+    void doesNotDetectNonExpired401() {
+        final String body =
+            "{"
+                + "\"errors\": ["
+                + "{ \"message\": \"401: unauthorized operation\" }"
+                + "]"
+                + "}";
+
+        assertThat(GraphQlErrorUtils.isExpiredToken(body)).isFalse();
+    }
+
+    @Test
+    void doesNotDetectWhenNoErrorsField() {
+        final String body =
+            "{"
+                + "\"data\": {"
+                + "\"something\": \"ok\""
+                + "}"
+                + "}";
+
+        assertThat(GraphQlErrorUtils.isExpiredToken(body)).isFalse();
+    }
+
+    @Test
+    void doesNotDetectWhenErrorsIsEmpty() {
+        final String body =
+            "{"
+                + "\"errors\": []"
+                + "}";
+
+        assertThat(GraphQlErrorUtils.isExpiredToken(body)).isFalse();
+    }
+
+    @Test
+    void returnsFalseForInvalidJson() {
+        assertThat(GraphQlErrorUtils.isExpiredToken("not-json")).isFalse();
+    }
+
+    @Test
+    void returnsFalseForNullBody() {
+        assertThat(GraphQlErrorUtils.isExpiredToken(null)).isFalse();
+    }
+
+    @Test
+    void returnsFalseForEmptyBody() {
+        assertThat(GraphQlErrorUtils.isExpiredToken("")).isFalse();
+    }
+}


### PR DESCRIPTION
Renew token for  basic auth was fine. 
The bug was when basic auth and "graphql" mode: in this case error 401 should be extracted from each 200 response with errors